### PR TITLE
fix(rewards): challenge detail 404 + redemption fulfill 500

### DIFF
--- a/packages/server/src/api/middleware/auth.middleware.ts
+++ b/packages/server/src/api/middleware/auth.middleware.ts
@@ -57,6 +57,20 @@ export function authenticate(req: Request, _res: Response, next: NextFunction) {
   const token = queryToken || header!.slice(7);
   try {
     const payload = jwt.verify(token, config.jwt.secret) as AuthPayload;
+    // Issue #21 — Tokens minted by EmpCloud SSO carry empcloudOrgId /
+    // empcloudUserId as strings (mysql2 returns BIGINT as string when the
+    // EmpCloud server signs the payload, jsonwebtoken preserves it). Every
+    // downstream service then does `entity.organization_id !== orgId`,
+    // which evaluates 1 !== "1" === true and throws NotFoundError. The
+    // list endpoints work because knex passes the value to MySQL which
+    // auto-coerces. Coerce here once so downstream code can keep using
+    // strict equality.
+    if (payload.empcloudOrgId != null) {
+      (payload as any).empcloudOrgId = Number(payload.empcloudOrgId);
+    }
+    if (payload.empcloudUserId != null) {
+      (payload as any).empcloudUserId = Number(payload.empcloudUserId);
+    }
     req.user = payload;
     next();
   } catch (err: any) {

--- a/packages/server/src/api/routes/redemption.routes.ts
+++ b/packages/server/src/api/routes/redemption.routes.ts
@@ -141,7 +141,12 @@ router.put(
     try {
       const orgId = req.user!.empcloudOrgId;
       const { id } = idParamSchema.parse(req.params);
-      const notes = req.body.notes as string | undefined;
+      // Issue #20 — The frontend calls PUT without a JSON body
+      // (apiPut(`/redemptions/${id}/fulfill`)), so req.body may be
+      // undefined. Defensive optional chain prevents the route from
+      // crashing on `req.body.notes` — admins can fulfill without a
+      // note from the list view, the detail page can still attach one.
+      const notes = req.body?.notes as string | undefined;
 
       const redemption = await redemptionService.fulfillRedemption(orgId, id, notes);
       const response: ApiResponse<typeof redemption> = { success: true, data: redemption };

--- a/packages/server/src/services/redemption/redemption.service.ts
+++ b/packages/server/src/services/redemption/redemption.service.ts
@@ -201,7 +201,14 @@ export async function fulfillRedemption(
   const updated = await db.update<RewardRedemption>(TABLE, id, {
     status: "fulfilled" as RedemptionStatus,
     review_note: notes ?? redemption.review_note ?? null,
-    fulfilled_at: new Date().toISOString(),
+    // Issue #20 — Pass a Date object, not toISOString(). MySQL's strict
+    // mode rejects ISO 8601 with a Z suffix ("2026-04-28T05:56:37.480Z")
+    // for TIMESTAMP columns; the mysql2 driver converts a Date object
+    // into the canonical "YYYY-MM-DD HH:MM:SS.mmm" form that MySQL
+    // accepts. The route was returning a 500 with the generic "An
+    // unexpected error occurred" message because the underlying
+    // ER_TRUNCATED_WRONG_VALUE bubbled up from the driver.
+    fulfilled_at: new Date(),
   } as any);
 
   logger.info(`Redemption ${id} fulfilled`);


### PR DESCRIPTION
## Summary

Two reproduced production bugs in one PR. Both surfaced because of implicit type / shape assumptions on the boundary between routes and services.

### Closes #21 — Challenges: "Challenge not found" on every card click

Tokens minted by EmpCloud SSO carry `empcloudOrgId` as a **string** (mysql2 reads `BIGINT` as string when serialising the original payload, JWT preserves type). Every service in the rewards module then does:

```ts
if (!entity || entity.organization_id !== orgId) throw new NotFoundError(...)
```

…which evaluates `1 !== "1" === true` and throws. The **list** endpoints coincidentally work because knex passes the value into MySQL where the WHERE clause auto-coerces; the **detail** endpoints all hit this strict-equality wall.

Same pattern is in 18 places across 7 services (badge, budget, challenge, kudos, milestone, settings…). Fix once, in the auth middleware:

```ts
if (payload.empcloudOrgId != null) {
  (payload as any).empcloudOrgId = Number(payload.empcloudOrgId);
}
```

Every downstream service now sees a number consistently.

### Closes #20 — Redemptions: "mark as fulfilled" → unexpected error

Two stacked bugs:

1. `fulfilledRedemption` wrote `fulfilled_at: new Date().toISOString()`, producing `"2026-04-28T05:56:37.480Z"`. MySQL strict mode rejects ISO 8601 with the `Z` suffix for `TIMESTAMP` columns (`ER_TRUNCATED_WRONG_VALUE`). Pass a `Date` object instead — the mysql2 driver formats it as `2026-04-28 05:56:37.480` which MySQL accepts. The error bubbled up to the global error handler and was sanitised to "An unexpected error occurred" in production.

2. The route read `req.body.notes` without optional chaining, but the frontend calls `apiPut('/redemptions/:id/fulfill')` with **no body**, so `req.body` is `undefined`. The route crashed with `Cannot read properties of undefined (reading 'notes')` before even reaching the service. Defensive `?.notes` lets the common no-body call through.

## Verified locally

- Minted a JWT with `empcloudOrgId: "1"` (string). Before fix: detail returned 404 NOT_FOUND. After fix: returns 200 with the full payload.
- Created an `approved` redemption, called `PUT /redemptions/:id/fulfill` without a body. Before fix: 500 INTERNAL_ERROR. After fix: 200 with `status: "fulfilled"` and a valid `fulfilled_at` timestamp.
- TypeScript build clean.

## Test plan

- [ ] Click any challenge card from the list → detail page loads (no "Challenge not found").
- [ ] Click "Mark as fulfilled" on an approved redemption → status flips to "fulfilled", no error toast.
- [ ] Approve, reject, fulfill, cancel — all four redemption actions still work.
- [ ] Other detail pages (badge, kudos, milestone, settings, budget) keep working — same coercion fix benefits them all.
