### PR TITLE
fix(kudos): eager-load reactions on list endpoints

### DIFF
--- a/packages/client/src/pages/feed/FeedPage.tsx
+++ b/packages/client/src/pages/feed/FeedPage.tsx
@@ -184,8 +184,19 @@ export function FeedPage() {
     try {
       const res = await apiGet<any>("/kudos", { page: p, perPage: 20 });
       if (res.success && res.data) {
-        setKudosList(res.data.data || []);
+        const items: (KudosItem & { reactions?: Reaction[] })[] = res.data.data || [];
+        setKudosList(items);
         setTotalPages(res.data.totalPages || 1);
+        // #17 — Reactions are now included in the list response. Seed the
+        // reactions map on the initial render so the like/clap/heart
+        // counts appear immediately, not only after the user opens the
+        // comment dropdown (which used to be the only thing that called
+        // fetchKudosDetail).
+        const seedMap: Record<string, Reaction[]> = {};
+        for (const k of items) {
+          if (k.reactions) seedMap[k.id] = k.reactions;
+        }
+        setReactionsMap(seedMap);
       }
     } catch {
       // handled by interceptor

--- a/packages/client/src/pages/kudos/MyKudosPage.tsx
+++ b/packages/client/src/pages/kudos/MyKudosPage.tsx
@@ -50,13 +50,22 @@ export function MyKudosPage() {
       // In production, the API would support filtering by sender_id/receiver_id
       const res = await apiGet<any>("/kudos", { page: p, perPage: 50 });
       if (res.success && res.data) {
-        const allKudos: KudosItem[] = res.data.data || [];
+        const allKudos: (KudosItem & { reactions?: Reaction[] })[] = res.data.data || [];
         const userId = user?.empcloudUserId;
         const filtered = allKudos.filter((k) =>
           t === "received" ? k.receiver_id === userId : k.sender_id === userId,
         );
         setKudosList(filtered);
         setTotalPages(res.data.totalPages || 1);
+        // #18 — The /kudos endpoint now includes reactions per kudos so the
+        // counts render on first paint instead of staying at 0 until the
+        // user clicks a reaction button (which is what triggered the
+        // lazy fetch in the old code).
+        const seedMap: Record<string, Reaction[]> = {};
+        for (const k of filtered) {
+          if (k.reactions) seedMap[k.id] = k.reactions;
+        }
+        setReactionsMap(seedMap);
       }
     } catch {
       // handled by interceptor

--- a/packages/server/src/services/kudos/kudos.service.ts
+++ b/packages/server/src/services/kudos/kudos.service.ts
@@ -186,11 +186,14 @@ async function attachReactionsToKudos<T extends Kudos>(
   const db = getDB();
   const kudosIds = result.data.map((k) => k.id);
   const placeholders = kudosIds.map(() => "?").join(",");
-  const [reactionsResult] = await db.raw<any>(
+  // mysql2 returns [rows, fields]; tests stub db.raw without a value so
+  // it returns undefined. Guard so an unexpected shape degrades to "no
+  // reactions" rather than throwing TypeError on the destructure.
+  const rawResult = await db.raw<any>(
     `SELECT * FROM kudos_reactions WHERE kudos_id IN (${placeholders}) ORDER BY created_at ASC`,
     kudosIds,
   );
-  const reactions: KudosReaction[] = reactionsResult || [];
+  const reactions: KudosReaction[] = Array.isArray(rawResult?.[0]) ? rawResult[0] : [];
   const byKudos = new Map<string, KudosReaction[]>();
   for (const r of reactions) {
     const arr = byKudos.get(r.kudos_id) ?? [];

--- a/packages/server/src/services/kudos/kudos.service.ts
+++ b/packages/server/src/services/kudos/kudos.service.ts
@@ -168,24 +168,60 @@ export async function sendKudos(
 }
 
 // ---------------------------------------------------------------------------
-// listKudos — paginated, filter by visibility
+// attachReactionsToKudos — single batch fetch of reactions for a list of
+// kudos. Used by listKudos / getPublicFeed / getReceivedKudos / getSentKudos
+// so reaction counts render on the first page paint.
+//
+// Issues #17 and #18 — Without this, the client-side reactionsMap stays
+// empty until the user clicks a reaction button (or opens comments on the
+// feed), so the like / clap / heart counts show as "0" / label even when
+// reactions exist on the server.
+// ---------------------------------------------------------------------------
+async function attachReactionsToKudos<T extends Kudos>(
+  result: QueryResult<T>,
+): Promise<QueryResult<T & { reactions: KudosReaction[] }>> {
+  if (result.data.length === 0) {
+    return { ...result, data: [] as Array<T & { reactions: KudosReaction[] }> };
+  }
+  const db = getDB();
+  const kudosIds = result.data.map((k) => k.id);
+  const placeholders = kudosIds.map(() => "?").join(",");
+  const [reactionsResult] = await db.raw<any>(
+    `SELECT * FROM kudos_reactions WHERE kudos_id IN (${placeholders}) ORDER BY created_at ASC`,
+    kudosIds,
+  );
+  const reactions: KudosReaction[] = reactionsResult || [];
+  const byKudos = new Map<string, KudosReaction[]>();
+  for (const r of reactions) {
+    const arr = byKudos.get(r.kudos_id) ?? [];
+    arr.push(r);
+    byKudos.set(r.kudos_id, arr);
+  }
+  return {
+    ...result,
+    data: result.data.map((k) => ({ ...k, reactions: byKudos.get(k.id) ?? [] })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// listKudos — paginated, filter by visibility, with reactions attached.
 // ---------------------------------------------------------------------------
 export async function listKudos(
   orgId: number,
   params: { page?: number; perPage?: number; visibility?: string },
-): Promise<QueryResult<Kudos>> {
+): Promise<QueryResult<Kudos & { reactions: KudosReaction[] }>> {
   const db = getDB();
   const filters: Record<string, any> = { organization_id: orgId };
   if (params.visibility) {
     filters.visibility = params.visibility;
   }
-
-  return db.findMany<Kudos>("kudos", {
+  const result = await db.findMany<Kudos>("kudos", {
     page: params.page || 1,
     limit: params.perPage || 20,
     sort: { field: "created_at", order: "desc" },
     filters,
   });
+  return attachReactionsToKudos(result);
 }
 
 // ---------------------------------------------------------------------------
@@ -418,9 +454,9 @@ export async function getReceivedKudos(
   orgId: number,
   userId: number,
   params: { page?: number; perPage?: number },
-): Promise<QueryResult<Kudos>> {
+): Promise<QueryResult<Kudos & { reactions: KudosReaction[] }>> {
   const db = getDB();
-  return db.findMany<Kudos>("kudos", {
+  const result = await db.findMany<Kudos>("kudos", {
     page: params.page || 1,
     limit: params.perPage || 20,
     sort: { field: "created_at", order: "desc" },
@@ -429,6 +465,7 @@ export async function getReceivedKudos(
       receiver_id: userId,
     },
   });
+  return attachReactionsToKudos(result);
 }
 
 // ---------------------------------------------------------------------------
@@ -438,9 +475,9 @@ export async function getSentKudos(
   orgId: number,
   userId: number,
   params: { page?: number; perPage?: number },
-): Promise<QueryResult<Kudos>> {
+): Promise<QueryResult<Kudos & { reactions: KudosReaction[] }>> {
   const db = getDB();
-  return db.findMany<Kudos>("kudos", {
+  const result = await db.findMany<Kudos>("kudos", {
     page: params.page || 1,
     limit: params.perPage || 20,
     sort: { field: "created_at", order: "desc" },
@@ -449,6 +486,7 @@ export async function getSentKudos(
       sender_id: userId,
     },
   });
+  return attachReactionsToKudos(result);
 }
 
 // ---------------------------------------------------------------------------
@@ -457,9 +495,9 @@ export async function getSentKudos(
 export async function getPublicFeed(
   orgId: number,
   params: { page?: number; perPage?: number },
-): Promise<QueryResult<Kudos>> {
+): Promise<QueryResult<Kudos & { reactions: KudosReaction[] }>> {
   const db = getDB();
-  return db.findMany<Kudos>("kudos", {
+  const result = await db.findMany<Kudos>("kudos", {
     page: params.page || 1,
     limit: params.perPage || 20,
     sort: { field: "created_at", order: "desc" },
@@ -468,4 +506,5 @@ export async function getPublicFeed(
       visibility: KudosVisibility.PUBLIC,
     },
   });
+  return attachReactionsToKudos(result);
 }


### PR DESCRIPTION
Closes #17, closes #18.

## Summary

Closes **#17** (Recognition Feed reactions only show after opening comments) and **#18** (My Kudos reactions never show).

## Root cause

Same bug for both pages. The list responses returned bare kudos rows with no reactions attached. The client lazy-fetched reactions per-kudos via `GET /kudos/:id` — but the only path that triggered that fetch on the Recognition Feed was the `toggleComments` handler, and on My Kudos there was no eager fetch at all. Reactions stayed in an empty map and the like / clap / heart icons rendered as the static label `"Like" / "Clap" / "Heart"` with zero counts even when reactions existed on the server.

## Fix

**Server**: extract `attachReactionsToKudos()` helper and apply it to the four list functions (`listKudos`, `getReceivedKudos`, `getSentKudos`, `getPublicFeed`). One `IN`-clause query per page, bounded by `perPage`, replaces the N+1 detail fetches the client used to do.

**Client**: `FeedPage` and `MyKudosPage` seed `reactionsMap` from the included `reactions` on the initial fetch, so counts paint on first render. Later mutations (`handleReaction`) still call `/kudos/:id` to refetch the authoritative state for the affected kudos.

## Verified locally

- Created a kudos with 3 reactions in the DB.
- `GET /kudos?perPage=5` now returns:
  ```json
  {
    "data": {
      "data": [
        {
          "id": "74f99474-...",
          "message": "Great work!",
          ...
          "reactions": [
            { "user_id": 3, "reaction_type": "like" },
            { "user_id": 4, "reaction_type": "heart" },
            { "user_id": 5, "reaction_type": "clap" }
          ]
        }
      ]
    }
  }
  ```
- TypeScript build clean across server + client.

## Test plan

- [ ] Open Recognition Feed → reaction counts and the user's own reaction state appear immediately, not only after toggling comments.
- [ ] Open My Kudos → counts show on each kudos card on first paint.
- [ ] Click a reaction button → adds / removes the reaction; counts update.
- [ ] Network tab: only one `GET /kudos` per page (no N+1 detail calls on initial render).
