### PR TITLE
fix(leaderboard,dashboard): period-aware kudos counts + clickable cards

### DIFF
--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import {
   Heart,
   Trophy,
@@ -77,6 +77,9 @@ export function DashboardPage() {
     })();
   }, [user?.empcloudUserId]);
 
+  // #16 — Each card deep-links to the page that explains its number.
+  // Points Balance → Rewards catalog (so users can spend); Kudos Sent /
+  // Received → My Kudos with the matching tab; Badges Earned → My Badges.
   const statCards = [
     {
       label: "Points Balance",
@@ -84,6 +87,8 @@ export function DashboardPage() {
       icon: Trophy,
       color: "bg-amber-50 text-amber-600",
       borderColor: "border-amber-200",
+      to: "/rewards",
+      ariaLabel: "View rewards you can redeem with your points",
     },
     {
       label: "Kudos Sent",
@@ -91,6 +96,8 @@ export function DashboardPage() {
       icon: Send,
       color: "bg-blue-50 text-blue-600",
       borderColor: "border-blue-200",
+      to: "/kudos?tab=sent",
+      ariaLabel: "View kudos you have sent",
     },
     {
       label: "Kudos Received",
@@ -98,6 +105,8 @@ export function DashboardPage() {
       icon: Heart,
       color: "bg-pink-50 text-pink-600",
       borderColor: "border-pink-200",
+      to: "/kudos?tab=received",
+      ariaLabel: "View kudos you have received",
     },
     {
       label: "Badges Earned",
@@ -105,6 +114,8 @@ export function DashboardPage() {
       icon: Award,
       color: "bg-purple-50 text-purple-600",
       borderColor: "border-purple-200",
+      to: "/badges/mine",
+      ariaLabel: "View badges you have earned",
     },
   ];
 
@@ -140,9 +151,14 @@ export function DashboardPage() {
       {/* Stat Cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {statCards.map((stat) => (
-          <div
+          <Link
             key={stat.label}
-            className={cn("rounded-lg border bg-white p-6", stat.borderColor)}
+            to={stat.to}
+            aria-label={stat.ariaLabel}
+            className={cn(
+              "block rounded-lg border bg-white p-6 transition-all hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400",
+              stat.borderColor,
+            )}
           >
             <div className={cn("inline-flex rounded-lg p-2.5", stat.color)}>
               <stat.icon className="h-5 w-5" />
@@ -151,7 +167,7 @@ export function DashboardPage() {
               {typeof stat.value === "number" ? stat.value.toLocaleString() : stat.value}
             </p>
             <p className="mt-1 text-sm text-gray-500">{stat.label}</p>
-          </div>
+          </Link>
         ))}
       </div>
 

--- a/packages/client/src/pages/kudos/MyKudosPage.tsx
+++ b/packages/client/src/pages/kudos/MyKudosPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Heart, ThumbsUp, Award, MessageSquare, Loader2 } from "lucide-react";
 import { apiGet, apiPost, apiDelete } from "@/api/client";
 import { getUser } from "@/lib/auth-store";
@@ -36,7 +37,20 @@ type Tab = "received" | "sent";
 
 export function MyKudosPage() {
   const user = getUser();
-  const [tab, setTab] = useState<Tab>("received");
+  // #16 — Honour ?tab=sent / ?tab=received deep-links from the dashboard
+  // cards so they open the matching tab directly instead of always
+  // landing on "received".
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab: Tab = searchParams.get("tab") === "sent" ? "sent" : "received";
+  const [tab, setTab] = useState<Tab>(initialTab);
+
+  // Keep the URL in sync so the back button + bookmarks behave correctly.
+  useEffect(() => {
+    if ((searchParams.get("tab") === "sent" ? "sent" : "received") !== tab) {
+      setSearchParams({ tab }, { replace: true });
+    }
+  }, [tab, searchParams, setSearchParams]);
+
   const [kudosList, setKudosList] = useState<KudosItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);

--- a/packages/server/src/services/leaderboard/leaderboard.service.ts
+++ b/packages/server/src/services/leaderboard/leaderboard.service.ts
@@ -32,6 +32,63 @@ interface LeaderboardResult {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #19 — period_key was being stored on snapshots and used to scope
+// the leaderboard, but the kudos / badge count subqueries had no date
+// filter. So a "weekly" leaderboard showed all-time kudos sent / received,
+// which was wrong. Convert (periodType, periodKey) to a date range and
+// pass an extra optional date predicate into each count subquery.
+//
+// All-time => returns null => no date filter => behaviour unchanged.
+//
+// Returned bounds are half-open: [start, end). Empty period_key (or "all")
+// short-circuits to all-time.
+// ---------------------------------------------------------------------------
+function periodToDateRange(periodType: string, periodKey: string): { start: Date; end: Date } | null {
+  if (!periodKey || periodKey === "all" || periodType === "all_time") return null;
+
+  // weekly: "2026-W17"
+  const weeklyMatch = /^(\d{4})-W(\d{2})$/.exec(periodKey);
+  if (weeklyMatch) {
+    const year = Number(weeklyMatch[1]);
+    const week = Number(weeklyMatch[2]);
+    // Approx: same algorithm as getCurrentPeriodKey in routes — Jan 1 + (week-1)*7 days,
+    // walked back to that week's Sunday so the range is monday..sunday.
+    const startOfYear = new Date(year, 0, 1);
+    const start = new Date(startOfYear);
+    start.setDate(startOfYear.getDate() + (week - 1) * 7 - startOfYear.getDay());
+    const end = new Date(start);
+    end.setDate(start.getDate() + 7);
+    return { start, end };
+  }
+
+  // monthly: "2026-04"
+  const monthlyMatch = /^(\d{4})-(\d{2})$/.exec(periodKey);
+  if (monthlyMatch) {
+    const year = Number(monthlyMatch[1]);
+    const month = Number(monthlyMatch[2]); // 1..12
+    return { start: new Date(year, month - 1, 1), end: new Date(year, month, 1) };
+  }
+
+  // quarterly: "2026-Q2"
+  const quarterlyMatch = /^(\d{4})-Q([1-4])$/.exec(periodKey);
+  if (quarterlyMatch) {
+    const year = Number(quarterlyMatch[1]);
+    const q = Number(quarterlyMatch[2]); // 1..4
+    const startMonth = (q - 1) * 3;
+    return { start: new Date(year, startMonth, 1), end: new Date(year, startMonth + 3, 1) };
+  }
+
+  // yearly: "2026"
+  const yearlyMatch = /^(\d{4})$/.exec(periodKey);
+  if (yearlyMatch) {
+    const year = Number(yearlyMatch[1]);
+    return { start: new Date(year, 0, 1), end: new Date(year + 1, 0, 1) };
+  }
+
+  return null; // unknown shape — treat as all-time so we don't accidentally hide everything
+}
+
+// ---------------------------------------------------------------------------
 // getLeaderboard — paginated leaderboard for a period
 // ---------------------------------------------------------------------------
 export async function getLeaderboard(
@@ -101,6 +158,10 @@ export async function getDepartmentLeaderboard(
 
   if (!rows || rows.length === 0) {
     // Compute live for department
+    // #19 — apply the same period-aware date filter as the global path.
+    const range = periodToDateRange(periodType, periodKey);
+    const dateClause = range ? `AND created_at >= ? AND created_at < ?` : "";
+    const dateParams: any[] = range ? [range.start, range.end] : [];
     const [liveRows] = await db.raw<any>(
       `SELECT
          pb.user_id,
@@ -111,13 +172,13 @@ export async function getDepartmentLeaderboard(
          u.first_name, u.last_name, u.email, u.designation, u.department_id
        FROM point_balances pb
        LEFT JOIN empcloud.users u ON u.id = pb.user_id
-       LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
-       LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
-       LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? GROUP BY user_id) be ON be.user_id = pb.user_id
+       LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
+       LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
+       LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? ${dateClause} GROUP BY user_id) be ON be.user_id = pb.user_id
        WHERE pb.organization_id = ? AND u.department_id = ? AND u.status = 1
        ORDER BY pb.total_earned DESC
        LIMIT 50`,
-      [orgId, orgId, orgId, orgId, departmentId],
+      [orgId, ...dateParams, orgId, ...dateParams, orgId, ...dateParams, orgId, departmentId],
     );
 
     return (liveRows || []).map((row: any, idx: number) => ({
@@ -192,6 +253,11 @@ export async function refreshLeaderboard(
   const db = getDB();
 
   // Compute rankings from points and kudos data
+  // #19 — apply period-aware date filter so weekly / monthly / quarterly /
+  // yearly snapshots persist counts that match the period selector.
+  const range = periodToDateRange(periodType, periodKey);
+  const dateClause = range ? `AND created_at >= ? AND created_at < ?` : "";
+  const dateParams: any[] = range ? [range.start, range.end] : [];
   const [rows] = await db.raw<any>(
     `SELECT
        pb.user_id,
@@ -201,12 +267,12 @@ export async function refreshLeaderboard(
        COALESCE(be.cnt, 0) as badges_earned
      FROM point_balances pb
      LEFT JOIN empcloud.users u ON u.id = pb.user_id
-     LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
-     LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
-     LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? GROUP BY user_id) be ON be.user_id = pb.user_id
+     LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
+     LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
+     LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? ${dateClause} GROUP BY user_id) be ON be.user_id = pb.user_id
      WHERE pb.organization_id = ? AND u.status = 1
      ORDER BY pb.total_earned DESC`,
-    [orgId, orgId, orgId, orgId],
+    [orgId, ...dateParams, orgId, ...dateParams, orgId, ...dateParams, orgId],
   );
 
   if (!rows || rows.length === 0) {
@@ -270,6 +336,11 @@ async function computeLiveLeaderboard(
   const db = getDB();
   const offset = (page - 1) * perPage;
 
+  // #19 — Build date-bounded count subqueries for the selected period.
+  const range = periodToDateRange(periodType, periodKey);
+  const dateClause = range ? `AND created_at >= ? AND created_at < ?` : "";
+  const dateParams: any[] = range ? [range.start, range.end] : [];
+
   const [rows] = await db.raw<any>(
     `SELECT
        pb.user_id,
@@ -280,13 +351,13 @@ async function computeLiveLeaderboard(
        u.first_name, u.last_name, u.email, u.designation, u.department_id
      FROM point_balances pb
      LEFT JOIN empcloud.users u ON u.id = pb.user_id
-     LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
-     LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
-     LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? GROUP BY user_id) be ON be.user_id = pb.user_id
+     LEFT JOIN (SELECT receiver_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY receiver_id) kr ON kr.receiver_id = pb.user_id
+     LEFT JOIN (SELECT sender_id, COUNT(*) as cnt FROM kudos WHERE organization_id = ? ${dateClause} GROUP BY sender_id) ks ON ks.sender_id = pb.user_id
+     LEFT JOIN (SELECT user_id, COUNT(*) as cnt FROM user_badges WHERE organization_id = ? ${dateClause} GROUP BY user_id) be ON be.user_id = pb.user_id
      WHERE pb.organization_id = ? AND u.status = 1
      ORDER BY pb.total_earned DESC
      LIMIT ? OFFSET ?`,
-    [orgId, orgId, orgId, orgId, perPage, offset],
+    [orgId, ...dateParams, orgId, ...dateParams, orgId, ...dateParams, orgId, perPage, offset],
   );
 
   const [countResult] = await db.raw<any>(


### PR DESCRIPTION
Closes #19, closes #16.

## Summary

Closes **#19** (Leaderboard sent count not showing correct) and **#16** (Dashboard cards not clickable).

## #19 — Leaderboard period was cosmetic

The leaderboard supports `weekly / monthly / quarterly / yearly / all_time` periods, but the kudos count subqueries had **no date predicate**:

```sql
LEFT JOIN (
  SELECT sender_id, COUNT(*) FROM kudos
  WHERE organization_id = ?
  GROUP BY sender_id
) ks ON ks.sender_id = pb.user_id
```

So switching to "This Week" still showed all-time numbers. The bug applies to `kudos_received`, `kudos_sent`, and `badges_earned` — three count subqueries, three live query paths (`computeLiveLeaderboard`, `getDepartmentLeaderboard` live fallback, `refreshLeaderboard` snapshot generator).

**Fix**: a `periodToDateRange(periodType, periodKey)` helper that converts the period key (e.g. `"2026-W17"`, `"2026-04"`, `"2026-Q2"`, `"2026"`) into a half-open `[start, end)` Date range. The three live paths now build an extra `AND created_at >= ? AND created_at < ?` clause when a range is returned, and pass through unchanged for `all_time` (so existing behaviour is preserved on that period).

Verified locally: inserted one kudos `NOW()` and one with `created_at = '2025-04-01'`, then queried both periods. Current-month leaderboard returns 1, all-time returns 2.

**Snapshot caveat**: the snapshot read path (`getLeaderboard`) returns persisted rows when present. After deploy, run `refreshLeaderboard()` for each tenant + period to populate fresh per-period counts; the live fallback handles tenants that never generated snapshots.

## #16 — Dashboard cards clickable

The four stat cards (Points Balance, Kudos Sent, Kudos Received, Badges Earned) were inert `<div>`s. Wrap each in a `Link` so the numbers deep-link to the page that explains them:

| Card | Destination |
|---|---|
| Points Balance | `/rewards` |
| Kudos Sent | `/kudos?tab=sent` |
| Kudos Received | `/kudos?tab=received` |
| Badges Earned | `/badges/mine` |

`MyKudosPage` now reads `?tab=sent\|received` from the URL on mount and writes the current tab back via `setSearchParams` as the user toggles, so back-button and bookmarks work too.

## Test plan

- [ ] Leaderboard → switch between periods → counts change accordingly.
- [ ] All-time period continues to show all-time counts.
- [ ] Dashboard cards: hover state visible; click each card → lands on correct page.
- [ ] `/kudos?tab=sent` opens MyKudos directly on the Sent tab; toggling tabs updates the URL.
- [ ] Keyboard nav (Tab + Enter) works on the cards.
