### PR TITLE
feat(send-kudos): real employee dropdown via /users/search

### DIFF
--- a/packages/client/src/pages/kudos/SendKudosPage.tsx
+++ b/packages/client/src/pages/kudos/SendKudosPage.tsx
@@ -36,25 +36,28 @@ export function SendKudosPage() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  // Mock employee search — in production this would call empcloud API
+  // #15 — Real employee search via /users/search (cross-DB lookup of
+  // empcloud.users, scoped to the caller's org and excluding the caller
+  // themselves). Debounced so we don't hammer the endpoint on every
+  // keystroke. An empty query still hits the endpoint so the dropdown
+  // shows the org's first 20 employees on initial focus, which is the
+  // shape the issue asks for ("dropdown for employee's field").
   useEffect(() => {
-    if (recipientSearch.length < 2) {
-      setRecipients([]);
-      return;
-    }
-
     const timer = setTimeout(async () => {
       try {
-        // This would be an empcloud API call in production
-        // For now we simulate with a placeholder
-        const res = await apiGet<any>("/kudos", { page: 1, perPage: 5 });
-        // Simulate employees from any available data
-        setRecipients([]);
+        const res = await apiGet<any>("/users/search", {
+          q: recipientSearch.trim(),
+          limit: 20,
+        });
+        if (res.success && Array.isArray(res.data)) {
+          setRecipients(res.data);
+        } else {
+          setRecipients([]);
+        }
       } catch {
-        // silent
+        setRecipients([]);
       }
-    }, 300);
-
+    }, 200);
     return () => clearTimeout(timer);
   }, [recipientSearch]);
 
@@ -183,7 +186,7 @@ export function SendKudosPage() {
               />
               {/* Dropdown for search results */}
               {showDropdown && recipients.length > 0 && (
-                <ul className="absolute left-0 right-0 top-full z-20 mt-1 max-h-48 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                <ul className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
                   {recipients.map((emp) => (
                     <li key={emp.id}>
                       <button
@@ -194,12 +197,24 @@ export function SendKudosPage() {
                           setShowDropdown(false);
                         }}
                       >
-                        <span className="font-medium text-gray-900">{emp.first_name} {emp.last_name}</span>
-                        {emp.email && <span className="ml-2 text-xs text-gray-400">{emp.email}</span>}
+                        <span className="font-medium text-gray-900">
+                          {emp.first_name} {emp.last_name}
+                        </span>
+                        {emp.designation && (
+                          <span className="ml-2 text-xs text-gray-500">{emp.designation}</span>
+                        )}
+                        {emp.email && (
+                          <span className="ml-2 text-xs text-gray-400">{emp.email}</span>
+                        )}
                       </button>
                     </li>
                   ))}
                 </ul>
+              )}
+              {showDropdown && recipientSearch.length > 0 && recipients.length === 0 && (
+                <div className="absolute left-0 right-0 top-full z-20 mt-1 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500 shadow-lg">
+                  No matching employees found.
+                </div>
               )}
               <p className="mt-1 text-xs text-gray-400">
                 Enter the Employee ID number directly if search is unavailable

--- a/packages/server/src/api/routes/user.routes.ts
+++ b/packages/server/src/api/routes/user.routes.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// USER ROUTES
+// Lightweight cross-DB lookup of empcloud.users so the rewards UI can offer
+// employee pickers (Send Kudos, Nominations, Challenge join, etc.) without
+// the user having to remember another employee's numeric ID. Issue #15.
+// ============================================================================
+
+import { Router, Request, Response, NextFunction } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import { getEmpCloudDB } from "../../db/empcloud";
+import { sendSuccess } from "../../utils/response";
+
+const router = Router();
+router.use(authenticate);
+
+// ---------------------------------------------------------------------------
+// GET /users/search?q=...&limit=20
+// Returns active users in the caller's org whose first/last/email matches
+// the query (case-insensitive prefix). Empty/short query returns the org's
+// first 20 users so the dropdown isn't useless on initial focus.
+// ---------------------------------------------------------------------------
+router.get("/search", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const orgId = req.user!.empcloudOrgId;
+    const callerId = req.user!.empcloudUserId;
+    const q = (req.query.q as string | undefined)?.trim() ?? "";
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit as string) || 20));
+
+    const db = getEmpCloudDB();
+    let query = db("users")
+      .where({ organization_id: orgId, status: 1 })
+      .whereNot({ id: callerId })
+      .select("id", "first_name", "last_name", "email", "designation");
+
+    if (q.length > 0) {
+      const like = `%${q}%`;
+      query = query.where((qb) => {
+        qb.where("first_name", "like", like)
+          .orWhere("last_name", "like", like)
+          .orWhere("email", "like", like)
+          .orWhereRaw("CONCAT(first_name, ' ', last_name) LIKE ?", [like]);
+      });
+    }
+
+    const rows = await query.orderBy("first_name", "asc").limit(limit);
+    return sendSuccess(res, rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export { router as userRoutes };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,7 @@ import { celebrationRoutes } from "./api/routes/celebration.routes";
 import { challengeRoutes } from "./api/routes/challenge.routes";
 import { milestoneRoutes } from "./api/routes/milestone.routes";
 import { authRoutes } from "./api/routes/auth.routes";
+import { userRoutes } from "./api/routes/user.routes";
 import { authenticate } from "./api/middleware/auth.middleware";
 import { errorHandler } from "./api/middleware/error.middleware";
 import { apiLimiter, authLimiter } from "./api/middleware/rate-limit.middleware";
@@ -106,6 +107,7 @@ v1.use("/celebrations", celebrationRoutes);
 v1.use("/challenges", challengeRoutes);
 v1.use("/milestones", milestoneRoutes);
 v1.use("/teams", teamsRoutes); // alias — /teams -> /settings/teams (#881)
+v1.use("/users", userRoutes);
 
 // #885: GET /integration/user/:userId/summary — combined user rewards summary
 v1.get("/integration/user/:userId/summary", authenticate,


### PR DESCRIPTION
Closes #15.

## Summary

Closes **#15**. The Send Kudos page used to mock the recipient search and fall back to a manual numeric Employee ID input — usable but clunky, and the issue title specifically asks for a proper dropdown.

## What this changes

**Server**: new `packages/server/src/api/routes/user.routes.ts` exposing:

```
GET /users/search?q=<text>&limit=<1..50>
```

The endpoint queries the `empcloud.users` table cross-DB (already used by `analytics.service.ts`, same access pattern), filtering on `organization_id`, `status = 1`, and excluding the caller themselves. Returns `id`, `first_name`, `last_name`, `email`, `designation`.

Empty / missing query returns the org's first N users so the dropdown is useful on initial focus, not just after typing.

**Client**: `SendKudosPage` swaps the mocked `apiGet("/kudos")` call for `apiGet("/users/search")`, debounces at 200 ms, and renders designation + email alongside each name in the dropdown. A "No matching employees found" hint appears when a non-empty query returns nothing. The existing manual-numeric-ID fallback stays as a power-user escape hatch.

## Verified locally

| Caller | Query | Result |
|---|---|---|
| user 1 (org 1, lone admin) | empty | 0 (only user in org, excluded) |
| user 2 (org 2) | empty | 5 active colleagues |
| user 2 (org 2) | `q=pri` | 1 (Priya Patel) |

## Test plan

- [ ] Send Kudos page → focus the recipient input → dropdown shows up to 20 employees from the org.
- [ ] Type 1–2 chars → results filter live; matches `first_name`, `last_name`, `email` and full-name (`first last`).
- [ ] Search yields no results → "No matching employees found" hint appears.
- [ ] Pick a result → recipient locks in; Send Kudos works end-to-end.
- [ ] Manual Employee ID fallback still works.
