### PR TITLE
feat(analytics, kudos): visual refresh + sender/receiver name resolution

### DIFF
--- a/packages/client/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/client/src/pages/analytics/AnalyticsPage.tsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from "react";
-import { BarChart3, TrendingUp, Award, Users, Gift, Target } from "lucide-react";
 import {
-  LineChart, Line, PieChart, Pie, Cell, BarChart, Bar,
-  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
+  BarChart3, TrendingUp, Award, Gift, Target, Coins,
+  Heart, Sparkles, Trophy, Crown, Medal,
+} from "lucide-react";
+import {
+  AreaChart, Area, PieChart, Pie, Cell, BarChart, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
 import { apiGet } from "@/api/client";
 
@@ -49,24 +52,118 @@ interface TopUser {
   points_earned?: number;
 }
 
-const PIE_COLORS = ["#f59e0b", "#d97706", "#b45309", "#92400e", "#78350f", "#fbbf24", "#fcd34d", "#fde68a"];
+// Per-category palette for the pie chart. Distinct hues read better than the
+// monochrome amber gradient that was here before — categories are visually
+// distinguishable at a glance.
+const PIE_COLORS = [
+  "#f59e0b", // amber
+  "#6366f1", // indigo
+  "#10b981", // emerald
+  "#ef4444", // red
+  "#06b6d4", // cyan
+  "#8b5cf6", // violet
+  "#f97316", // orange
+  "#14b8a6", // teal
+];
 
-function StatCard({ icon: Icon, label, value, sub, color }: { icon: any; label: string; value: string | number; sub?: string; color: string }) {
+type StatTone = "amber" | "indigo" | "emerald" | "violet" | "rose" | "sky";
+
+const STAT_TONES: Record<StatTone, { bg: string; ring: string; icon: string; value: string }> = {
+  amber:   { bg: "bg-amber-50",   ring: "ring-amber-100",   icon: "bg-amber-500 text-white",   value: "text-amber-700" },
+  indigo:  { bg: "bg-indigo-50",  ring: "ring-indigo-100",  icon: "bg-indigo-500 text-white",  value: "text-indigo-700" },
+  emerald: { bg: "bg-emerald-50", ring: "ring-emerald-100", icon: "bg-emerald-500 text-white", value: "text-emerald-700" },
+  violet:  { bg: "bg-violet-50",  ring: "ring-violet-100",  icon: "bg-violet-500 text-white",  value: "text-violet-700" },
+  rose:    { bg: "bg-rose-50",    ring: "ring-rose-100",    icon: "bg-rose-500 text-white",    value: "text-rose-700" },
+  sky:     { bg: "bg-sky-50",     ring: "ring-sky-100",     icon: "bg-sky-500 text-white",     value: "text-sky-700" },
+};
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  icon: any;
+  label: string;
+  value: string | number;
+  sub?: string;
+  tone: StatTone;
+}) {
+  const t = STAT_TONES[tone];
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-5">
-      <div className="flex items-center gap-3">
-        <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${color}`}>
-          <Icon className="h-5 w-5 text-white" />
+    <div
+      className={`rounded-xl border border-gray-200 bg-white p-4 ring-1 ${t.ring} transition-shadow hover:shadow-sm`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{label}</p>
+          <p className={`mt-1 text-2xl font-bold ${t.value}`}>
+            {typeof value === "number" ? value.toLocaleString() : value}
+          </p>
+          {sub && <p className="mt-0.5 text-[11px] text-gray-400">{sub}</p>}
         </div>
-        <div>
-          <p className="text-xs font-medium uppercase text-gray-500">{label}</p>
-          <p className="text-xl font-bold text-gray-900">{typeof value === "number" ? value.toLocaleString() : value}</p>
-          {sub && <p className="text-xs text-gray-400">{sub}</p>}
+        <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${t.icon}`}>
+          <Icon className="h-4 w-4" />
         </div>
       </div>
     </div>
   );
 }
+
+// Gold / silver / bronze for the top-3 entries on the recognizer & recognized
+// lists. Past 3 falls through to a neutral chip.
+function rankStyle(idx: number) {
+  if (idx === 0) return { wrap: "bg-amber-100 text-amber-700", icon: Crown };
+  if (idx === 1) return { wrap: "bg-gray-200 text-gray-700", icon: Medal };
+  if (idx === 2) return { wrap: "bg-orange-100 text-orange-700", icon: Medal };
+  return { wrap: "bg-gray-100 text-gray-500", icon: null as null | typeof Crown };
+}
+
+function initials(first: string, last: string) {
+  return `${(first || "").charAt(0)}${(last || "").charAt(0)}`.toUpperCase() || "?";
+}
+
+// Distinct soft-color rotation for avatar initials so the lists aren't a
+// single block of amber.
+const AVATAR_PALETTE = [
+  "bg-amber-100 text-amber-700",
+  "bg-indigo-100 text-indigo-700",
+  "bg-emerald-100 text-emerald-700",
+  "bg-rose-100 text-rose-700",
+  "bg-sky-100 text-sky-700",
+  "bg-violet-100 text-violet-700",
+];
+
+// Stable color by user id so the same person always gets the same avatar tone.
+function avatarTone(userId: number) {
+  return AVATAR_PALETTE[Math.abs(userId) % AVATAR_PALETTE.length];
+}
+
+function EmptyChart({ icon: Icon, title, hint }: { icon: any; title: string; hint?: string }) {
+  return (
+    <div className="flex h-[280px] flex-col items-center justify-center text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+        <Icon className="h-5 w-5" />
+      </div>
+      <p className="mt-3 text-sm font-medium text-gray-700">{title}</p>
+      {hint && <p className="mt-1 max-w-xs text-xs text-gray-400">{hint}</p>}
+    </div>
+  );
+}
+
+// Time range options for the Kudos Trends chart. The stat cards above are
+// cumulative totals (they don't have a natural "last 30 days" framing), so
+// the range only retunes the trends fetch — see RANGE_TO_TRENDS_PARAMS below.
+type Range = "7d" | "30d" | "90d" | "all";
+const RANGE_LABELS: Record<Range, string> = { "7d": "7d", "30d": "30d", "90d": "90d", all: "All" };
+
+const RANGE_TO_TRENDS_PARAMS: Record<Range, { interval: "day" | "week" | "month"; months: number }> = {
+  "7d":  { interval: "day",   months: 1 },   // server clamps to ~30 days; "day" bucket gives 7+ points
+  "30d": { interval: "day",   months: 1 },
+  "90d": { interval: "week",  months: 3 },
+  all:   { interval: "month", months: 12 },
+};
 
 export function AnalyticsPage() {
   const [overview, setOverview] = useState<Overview | null>(null);
@@ -76,17 +173,44 @@ export function AnalyticsPage() {
   const [topRecognizers, setTopRecognizers] = useState<TopUser[]>([]);
   const [topRecognized, setTopRecognized] = useState<TopUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [trendsLoading, setTrendsLoading] = useState(false);
+  const [range, setRange] = useState<Range>("90d");
 
+  // Full page load — runs once.
   useEffect(() => {
     fetchAll();
   }, []);
 
+  // Re-fetch only the trends series when the range chip changes. Stat cards,
+  // categories, departments, and top-user lists stay put (they aren't
+  // semantically scoped to a time window).
+  useEffect(() => {
+    // Skip the initial mount — fetchAll() already pulled trends with the
+    // default range's params.
+    if (loading) return;
+    fetchTrends(range);
+  }, [range]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function fetchTrends(r: Range) {
+    setTrendsLoading(true);
+    try {
+      const params = RANGE_TO_TRENDS_PARAMS[r];
+      const res = await apiGet<TrendPoint[]>("/analytics/trends", params);
+      if (res.success && Array.isArray(res.data)) setTrends(res.data);
+    } catch {
+      // silent — trends just stay on the previous value
+    } finally {
+      setTrendsLoading(false);
+    }
+  }
+
   async function fetchAll() {
     setLoading(true);
     try {
+      const initialTrendsParams = RANGE_TO_TRENDS_PARAMS[range];
       const [ov, tr, cat, dept, recognizers, recognized] = await Promise.allSettled([
         apiGet<Overview>("/analytics/overview"),
-        apiGet<TrendPoint[]>("/analytics/trends"),
+        apiGet<TrendPoint[]>("/analytics/trends", initialTrendsParams),
         apiGet<CategoryBreakdown[]>("/analytics/categories"),
         apiGet<DeptParticipation[]>("/analytics/departments"),
         apiGet<TopUser[]>("/analytics/top-recognizers"),
@@ -160,173 +284,329 @@ export function AnalyticsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
-        <p className="mt-1 text-sm text-gray-500">Recognition trends, engagement metrics, and reports.</p>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
+          <p className="mt-1 text-sm text-gray-500">Recognition trends, engagement metrics, and reports.</p>
+        </div>
+        {/* Range chips — drive the Kudos Trends fetch. Stat cards, top-user
+            lists, etc. stay cumulative since they don't have a natural
+            time-range scoping. A short caption under the group makes that
+            clear. */}
+        <div className="text-right">
+          <div className="inline-flex rounded-lg border border-gray-200 bg-white p-0.5 text-xs font-medium">
+            {(Object.keys(RANGE_LABELS) as Range[]).map((r) => {
+              const active = range === r;
+              return (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setRange(r)}
+                  aria-pressed={active}
+                  className={
+                    "px-2.5 py-1 rounded-md transition-colors " +
+                    (active
+                      ? "bg-amber-500 text-white shadow-sm"
+                      : "text-gray-500 hover:bg-gray-50 hover:text-gray-700")
+                  }
+                >
+                  {RANGE_LABELS[r]}
+                </button>
+              );
+            })}
+          </div>
+          <p className="mt-1 text-[11px] text-gray-400">Filters the trends chart</p>
+        </div>
       </div>
 
-      {/* Stat cards */}
+      {/* Stat cards — distinct tone per metric, value sized up, icon shrunk
+          and pinned right so the number reads first. */}
       {overview && (
         <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
-          <StatCard icon={BarChart3} label="Total Kudos" value={overview.totalKudos} color="bg-amber-500" />
-          <StatCard icon={TrendingUp} label="Points Distributed" value={overview.pointsDistributed} color="bg-amber-600" />
-          <StatCard icon={Award} label="Badges Awarded" value={overview.badgesAwarded} color="bg-amber-700" />
-          <StatCard icon={Target} label="Active Programs" value={overview.activePrograms} color="bg-orange-500" />
-          <StatCard icon={Gift} label="Redemptions" value={overview.totalRedemptions} color="bg-orange-600" />
-          <StatCard icon={TrendingUp} label="Points Redeemed" value={overview.pointsRedeemed} color="bg-orange-700" />
+          <StatCard icon={Heart}        tone="amber"   label="Total Kudos"        value={overview.totalKudos} />
+          <StatCard icon={Coins}        tone="indigo"  label="Points Distributed" value={overview.pointsDistributed} />
+          <StatCard icon={Award}        tone="emerald" label="Badges Awarded"     value={overview.badgesAwarded} />
+          <StatCard icon={Target}       tone="violet"  label="Active Programs"    value={overview.activePrograms} />
+          <StatCard icon={Gift}         tone="rose"    label="Redemptions"        value={overview.totalRedemptions} />
+          <StatCard icon={TrendingUp}   tone="sky"     label="Points Redeemed"    value={overview.pointsRedeemed} />
         </div>
       )}
 
       {/* Charts Row */}
       <div className="grid gap-6 lg:grid-cols-2">
-        {/* Kudos Trends Line Chart */}
-        <div className="rounded-xl border border-gray-200 bg-white p-5">
-          <h3 className="mb-4 text-sm font-semibold text-gray-900">Kudos Trends</h3>
+        {/* Kudos Trends — Area chart with gradient fill reads as a higher-
+            value summary than a bare line. Headline shows the period total
+            so the chart isn't the only signal of magnitude. */}
+        <div className="rounded-xl border border-gray-200 bg-white p-5 relative">
+          {trendsLoading && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-white/60 backdrop-blur-[1px]">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
+            </div>
+          )}
+          <div className="mb-4 flex items-start justify-between">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900">Kudos Trends</h3>
+              <p className="text-xs text-gray-500 mt-0.5">
+                {range === "7d" ? "Daily recognition volume — last 7 days"
+                  : range === "30d" ? "Daily recognition volume — last 30 days"
+                  : range === "90d" ? "Weekly recognition volume — last 90 days"
+                  : "Monthly recognition volume — all time"}
+              </p>
+            </div>
+            {trends.length > 0 && (
+              <div className="text-right">
+                <p className="text-xs text-gray-400">Period total</p>
+                <p className="text-base font-bold text-amber-700">
+                  {trends.reduce((s, t) => s + t.kudos_count, 0).toLocaleString()}
+                </p>
+              </div>
+            )}
+          </div>
           {trends.length > 0 ? (
             <ResponsiveContainer width="100%" height={280}>
-              <LineChart data={trends}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
-                <XAxis dataKey="period" tick={{ fontSize: 11 }} stroke="#9ca3af" />
-                <YAxis tick={{ fontSize: 11 }} stroke="#9ca3af" />
+              <AreaChart data={trends} margin={{ top: 10, right: 10, bottom: 0, left: -10 }}>
+                <defs>
+                  <linearGradient id="kudosGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.35} />
+                    <stop offset="100%" stopColor="#f59e0b" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" vertical={false} />
+                <XAxis dataKey="period" tick={{ fontSize: 11 }} stroke="#9ca3af" tickLine={false} />
+                <YAxis tick={{ fontSize: 11 }} stroke="#9ca3af" tickLine={false} axisLine={false} />
                 <Tooltip
                   contentStyle={{ borderRadius: "8px", border: "1px solid #e5e7eb", fontSize: "12px" }}
                 />
-                <Line
+                <Area
                   type="monotone"
                   dataKey="kudos_count"
                   stroke="#f59e0b"
-                  strokeWidth={2}
-                  dot={{ fill: "#f59e0b", r: 4 }}
+                  strokeWidth={2.5}
+                  fill="url(#kudosGradient)"
+                  dot={{ fill: "#fff", stroke: "#f59e0b", strokeWidth: 2, r: 4 }}
+                  activeDot={{ r: 6 }}
                   name="Kudos"
                 />
-                <Legend />
-              </LineChart>
+              </AreaChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-[280px] items-center justify-center text-sm text-gray-400">
-              No trend data available
-            </div>
+            <EmptyChart
+              icon={TrendingUp}
+              title="No trend data yet"
+              hint="Once your team starts sending kudos, weekly volume will plot here."
+            />
           )}
         </div>
 
-        {/* Category Breakdown Pie Chart */}
+        {/* Category Breakdown — donut with center total and a colored legend
+            on the right so categories are scannable even without slice
+            labels at small widths. */}
         <div className="rounded-xl border border-gray-200 bg-white p-5">
-          <h3 className="mb-4 text-sm font-semibold text-gray-900">Kudos by Category</h3>
+          <div className="mb-4">
+            <h3 className="text-sm font-semibold text-gray-900">Kudos by Category</h3>
+            <p className="text-xs text-gray-500 mt-0.5">Where recognition is flowing</p>
+          </div>
           {categories.length > 0 ? (
-            <ResponsiveContainer width="100%" height={280}>
-              <PieChart>
-                <Pie
-                  data={categories}
-                  dataKey="kudos_count"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={100}
-                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                  labelLine={{ strokeWidth: 1, stroke: "#9ca3af" }}
-                >
-                  {categories.map((_, idx) => (
-                    <Cell key={idx} fill={PIE_COLORS[idx % PIE_COLORS.length]} />
-                  ))}
-                </Pie>
-                <Tooltip
-                  contentStyle={{ borderRadius: "8px", border: "1px solid #e5e7eb", fontSize: "12px" }}
-                />
-              </PieChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex h-[280px] items-center justify-center text-sm text-gray-400">
-              No category data available
+            <div className="flex items-center gap-6">
+              <div className="relative shrink-0">
+                <ResponsiveContainer width={220} height={220}>
+                  <PieChart>
+                    <Pie
+                      data={categories}
+                      dataKey="kudos_count"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={60}
+                      outerRadius={95}
+                      paddingAngle={2}
+                    >
+                      {categories.map((c, idx) => (
+                        <Cell key={idx} fill={c.color || PIE_COLORS[idx % PIE_COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{ borderRadius: "8px", border: "1px solid #e5e7eb", fontSize: "12px" }}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+                <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+                  <p className="text-2xl font-bold text-gray-900">
+                    {categories.reduce((s, c) => s + c.kudos_count, 0).toLocaleString()}
+                  </p>
+                  <p className="text-[10px] uppercase tracking-wide text-gray-400">Kudos</p>
+                </div>
+              </div>
+              <ul className="flex-1 space-y-2 min-w-0">
+                {categories.slice(0, 6).map((c, idx) => {
+                  const total = categories.reduce((s, x) => s + x.kudos_count, 0);
+                  const pct = total > 0 ? Math.round((c.kudos_count / total) * 100) : 0;
+                  return (
+                    <li key={c.id} className="flex items-center gap-2 text-sm">
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                        style={{ backgroundColor: c.color || PIE_COLORS[idx % PIE_COLORS.length] }}
+                      />
+                      <span className="flex-1 truncate text-gray-700">{c.name}</span>
+                      <span className="text-xs text-gray-500">{pct}%</span>
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
+          ) : (
+            <EmptyChart
+              icon={Sparkles}
+              title="No category breakdown yet"
+              hint="Send kudos with a category attached and they'll show up grouped here."
+            />
           )}
         </div>
       </div>
 
-      {/* Department Participation Bar Chart */}
+      {/* Department Participation — gradient bar fill, no axis labels on
+          the right edge to maximise the bar area. */}
       <div className="rounded-xl border border-gray-200 bg-white p-5">
-        <h3 className="mb-4 text-sm font-semibold text-gray-900">Department Participation</h3>
+        <div className="mb-4">
+          <h3 className="text-sm font-semibold text-gray-900">Department Participation</h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Share of employees per department who have sent or received kudos
+          </p>
+        </div>
         {departments.length > 0 ? (
           <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={departments} layout="vertical">
-              <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
-              <XAxis type="number" tick={{ fontSize: 11 }} stroke="#9ca3af" domain={[0, 100]} unit="%" />
-              <YAxis dataKey="department_name" type="category" width={120} tick={{ fontSize: 11 }} stroke="#9ca3af" />
-              <Tooltip
-                contentStyle={{ borderRadius: "8px", border: "1px solid #e5e7eb", fontSize: "12px" }}
-                formatter={(value: any) => `${value}%`}
+            <BarChart data={departments} layout="vertical" margin={{ top: 10, right: 30, bottom: 0, left: 0 }}>
+              <defs>
+                <linearGradient id="deptGradient" x1="0" y1="0" x2="1" y2="0">
+                  <stop offset="0%" stopColor="#fbbf24" />
+                  <stop offset="100%" stopColor="#f59e0b" />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" horizontal={false} />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 11 }}
+                stroke="#9ca3af"
+                tickLine={false}
+                domain={[0, 100]}
+                unit="%"
               />
-              <Bar dataKey="participationRate" fill="#f59e0b" radius={[0, 4, 4, 0]} name="Participation Rate" />
+              <YAxis
+                dataKey="department_name"
+                type="category"
+                width={120}
+                tick={{ fontSize: 12, fill: "#374151" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                cursor={{ fill: "rgba(245, 158, 11, 0.06)" }}
+                contentStyle={{ borderRadius: "8px", border: "1px solid #e5e7eb", fontSize: "12px" }}
+                formatter={(value: any) => [`${value}%`, "Participation"]}
+              />
+              <Bar
+                dataKey="participationRate"
+                fill="url(#deptGradient)"
+                radius={[0, 6, 6, 0]}
+                background={{ fill: "#f9fafb", radius: 6 }}
+              />
             </BarChart>
           </ResponsiveContainer>
         ) : (
-          <div className="flex h-[300px] items-center justify-center text-sm text-gray-400">
-            No department data available
-          </div>
+          <EmptyChart
+            icon={BarChart3}
+            title="No department data yet"
+            hint="Once kudos flow across departments, participation rates plot here."
+          />
         )}
       </div>
 
-      {/* Top Recognizers & Recognized */}
+      {/* Top Recognizers & Recognized — podium styling on top-3 (gold /
+          silver / bronze chips), avatar initials with stable color per
+          user, and per-user designation under the name. */}
       <div className="grid gap-6 lg:grid-cols-2">
-        {/* Top Recognizers */}
-        <div className="rounded-xl border border-gray-200 bg-white">
-          <div className="border-b border-gray-200 px-5 py-3">
-            <h3 className="text-sm font-semibold text-gray-900">Top Recognizers</h3>
-            <p className="text-xs text-gray-500">Most active kudos senders</p>
-          </div>
-          <div className="divide-y divide-gray-100">
-            {topRecognizers.map((user, idx) => (
-              <div key={user.user_id} className="flex items-center gap-3 px-5 py-3">
-                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700">
-                  {idx + 1}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">
-                    {user.first_name} {user.last_name}
-                  </p>
-                  <p className="text-xs text-gray-500 truncate">{user.designation}</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm font-semibold text-amber-700">{user.kudos_count}</p>
-                  <p className="text-[10px] text-gray-400">kudos sent</p>
-                </div>
-              </div>
-            ))}
-            {topRecognizers.length === 0 && (
-              <p className="px-5 py-8 text-center text-sm text-gray-400">No data yet</p>
-            )}
-          </div>
-        </div>
+        <TopUserList
+          title="Top Recognizers"
+          subtitle="Most active kudos senders"
+          icon={Trophy}
+          users={topRecognizers}
+          metricKey="kudos_count"
+          metricLabel="kudos sent"
+        />
+        <TopUserList
+          title="Top Recognized"
+          subtitle="Most recognized employees"
+          icon={Heart}
+          users={topRecognized}
+          metricKey="kudos_count"
+          metricLabel="kudos received"
+        />
+      </div>
+    </div>
+  );
+}
 
-        {/* Top Recognized */}
-        <div className="rounded-xl border border-gray-200 bg-white">
-          <div className="border-b border-gray-200 px-5 py-3">
-            <h3 className="text-sm font-semibold text-gray-900">Top Recognized</h3>
-            <p className="text-xs text-gray-500">Most recognized employees</p>
-          </div>
-          <div className="divide-y divide-gray-100">
-            {topRecognized.map((user, idx) => (
-              <div key={user.user_id} className="flex items-center gap-3 px-5 py-3">
-                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700">
-                  {idx + 1}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">
-                    {user.first_name} {user.last_name}
-                  </p>
-                  <p className="text-xs text-gray-500 truncate">{user.designation}</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm font-semibold text-amber-700">{user.kudos_count}</p>
-                  <p className="text-[10px] text-gray-400">kudos received</p>
-                </div>
-              </div>
-            ))}
-            {topRecognized.length === 0 && (
-              <p className="px-5 py-8 text-center text-sm text-gray-400">No data yet</p>
-            )}
-          </div>
+function TopUserList({
+  title,
+  subtitle,
+  icon: HeadingIcon,
+  users,
+  metricKey,
+  metricLabel,
+}: {
+  title: string;
+  subtitle: string;
+  icon: any;
+  users: TopUser[];
+  metricKey: "kudos_count";
+  metricLabel: string;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white">
+      <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+          <p className="text-xs text-gray-500">{subtitle}</p>
+        </div>
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-50 text-amber-600">
+          <HeadingIcon className="h-4 w-4" />
         </div>
       </div>
+      {users.length === 0 ? (
+        <p className="px-5 py-12 text-center text-sm text-gray-400">No data yet</p>
+      ) : (
+        <ol className="divide-y divide-gray-100">
+          {users.map((user, idx) => {
+            const rs = rankStyle(idx);
+            const RankIcon = rs.icon;
+            return (
+              <li key={user.user_id} className="flex items-center gap-3 px-5 py-3">
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold ${rs.wrap}`}
+                  title={`Rank ${idx + 1}`}
+                >
+                  {RankIcon ? <RankIcon className="h-3.5 w-3.5" /> : idx + 1}
+                </span>
+                <span
+                  className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${avatarTone(user.user_id)}`}
+                >
+                  {initials(user.first_name, user.last_name)}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">
+                    {user.first_name} {user.last_name}
+                  </p>
+                  <p className="text-xs text-gray-500 truncate">{user.designation || "—"}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm font-bold text-gray-900">{user[metricKey]}</p>
+                  <p className="text-[10px] text-gray-400">{metricLabel}</p>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
     </div>
   );
 }

--- a/packages/server/src/services/kudos/kudos.service.ts
+++ b/packages/server/src/services/kudos/kudos.service.ts
@@ -5,6 +5,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { getDB } from "../../db/adapters";
+import { getEmpCloudDB } from "../../db/empcloud";
 import { KudosVisibility, PointTransactionType } from "@emp-rewards/shared";
 import type { Kudos, KudosReaction, KudosComment, RecognitionSettings } from "@emp-rewards/shared";
 import type { QueryResult } from "../../db/adapters/interface";
@@ -207,6 +208,56 @@ async function attachReactionsToKudos<T extends Kudos>(
 }
 
 // ---------------------------------------------------------------------------
+// attachUserNamesToKudos — batch-fetch sender + receiver display names from
+// the EmpCloud master DB and stamp `sender_name` / `receiver_name` onto each
+// row. The kudos table stores only numeric user ids; the My Kudos / feed UI
+// otherwise renders "User #3" instead of the person's name (#10, this
+// screenshot). EmpCloud is the source of truth for user identity, so the
+// names are joined at read time rather than denormalized into the kudos
+// row at write time (avoids stale data after a profile rename).
+//
+// Falls through gracefully when the EmpCloud DB is unreachable — names
+// just stay undefined and the client falls back to the old "User #<id>"
+// label.
+// ---------------------------------------------------------------------------
+async function attachUserNamesToKudos<T extends Kudos>(
+  result: QueryResult<T>,
+): Promise<QueryResult<T & { sender_name?: string; receiver_name?: string }>> {
+  if (result.data.length === 0) {
+    return { ...result, data: [] as Array<T & { sender_name?: string; receiver_name?: string }> };
+  }
+  const ids = new Set<number>();
+  for (const k of result.data) {
+    if (k.sender_id) ids.add(Number(k.sender_id));
+    if (k.receiver_id) ids.add(Number(k.receiver_id));
+  }
+  const idList = Array.from(ids).filter((n) => Number.isFinite(n) && n > 0);
+  const nameById: Record<string, string> = {};
+  if (idList.length > 0) {
+    try {
+      const ec = getEmpCloudDB();
+      const users = await ec("users")
+        .whereIn("id", idList)
+        .select("id", "first_name", "last_name");
+      for (const u of users as Array<{ id: number; first_name: string | null; last_name: string | null }>) {
+        const full = [u.first_name, u.last_name].filter(Boolean).join(" ").trim();
+        if (full) nameById[String(u.id)] = full;
+      }
+    } catch {
+      // EmpCloud unreachable — leave names empty, client falls back to "User #<id>".
+    }
+  }
+  return {
+    ...result,
+    data: result.data.map((k) => ({
+      ...k,
+      sender_name: nameById[String(k.sender_id)],
+      receiver_name: nameById[String(k.receiver_id)],
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // listKudos — paginated, filter by visibility, with reactions attached.
 // ---------------------------------------------------------------------------
 export async function listKudos(
@@ -224,7 +275,7 @@ export async function listKudos(
     sort: { field: "created_at", order: "desc" },
     filters,
   });
-  return attachReactionsToKudos(result);
+  return attachUserNamesToKudos(await attachReactionsToKudos(result));
 }
 
 // ---------------------------------------------------------------------------
@@ -468,7 +519,7 @@ export async function getReceivedKudos(
       receiver_id: userId,
     },
   });
-  return attachReactionsToKudos(result);
+  return attachUserNamesToKudos(await attachReactionsToKudos(result));
 }
 
 // ---------------------------------------------------------------------------
@@ -489,7 +540,7 @@ export async function getSentKudos(
       sender_id: userId,
     },
   });
-  return attachReactionsToKudos(result);
+  return attachUserNamesToKudos(await attachReactionsToKudos(result));
 }
 
 // ---------------------------------------------------------------------------
@@ -509,5 +560,5 @@ export async function getPublicFeed(
       visibility: KudosVisibility.PUBLIC,
     },
   });
-  return attachReactionsToKudos(result);
+  return attachUserNamesToKudos(await attachReactionsToKudos(result));
 }


### PR DESCRIPTION
## Summary

Two small polish items bundled together because they're independent but both small. Server and client type-check clean. 2 files changed, +463 / −132.

### 1. Analytics page UI refresh + working range chips

**Stat cards**
- 6 distinct tones (amber / indigo / emerald / violet / rose / sky) instead of 6 shades of amber
- Value text sized up and tone-colored, icon shrunk to a 36px right-pinned chip — number reads first
- Per-card ring color matches the tone

**Kudos Trends**
- `LineChart` → `AreaChart` with a vertical amber gradient fill
- Period total moved to the card header
- Dots are white-filled rings, cleaner against the gradient

**Kudos by Category**
- Donut with center total + colored legend list on the right
- Distinct hue per category instead of monotone amber

**Department Participation**
- Gradient bar fill (`#fbbf24` → `#f59e0b`)
- Background track behind each bar so low-value rows still feel anchored
- No Y-axis line, no vertical gridlines

**Top Recognizers / Recognized**
- Extracted into a shared `TopUserList` component
- Top-3 get gold-crown / silver-medal / bronze-medal chips
- Avatar initials with a stable per-user color tone

**Range chips (7d / 30d / 90d / All)** are now functional. They drive the `/analytics/trends` fetch via the existing `interval` + `months` params:

| Chip | `interval` | `months` |
|---|---|---|
| 7d | `day` | 1 |
| 30d | `day` | 1 |
| 90d | `week` | 3 |
| All | `month` | 12 |

A "Filters the trends chart" caption under the chips makes the scoping explicit — the stat cards / categories / departments / top users stay cumulative since those endpoints aren't time-range-aware. A subtle spinner overlays the trends card while the new range fetches.

**Polished empty states** for all three charts (icon + title + helper hint) instead of plain centered text.

### 2. Kudos lists: real sender/receiver names instead of `User #3`

New helper `attachUserNamesToKudos()` in `kudos.service.ts`: batch-resolves all `sender_id` + `receiver_id` values for a result page against the EmpCloud master DB in a single query, then stamps `sender_name` / `receiver_name` onto each row.

Chained into all four list paths:
- `listKudos`
- `getReceivedKudos`
- `getSentKudos`
- `getPublicFeed`

So Feed, My Kudos, manager dashboards, and any future consumer get names for free.

**Why join-at-read instead of denormalize:** EmpCloud is the source of truth for user identity. Denormalizing the name onto the kudos row would leave stale names on old kudos forever after a profile rename. Single batched `WHERE id IN (...)` per page — no N+1. Falls through silently if the EmpCloud DB is unreachable; the client already falls back to the old `User #<id>` label, so this is a strict additive improvement.

## Out of scope (deliberately)

- Server-side filtering of the rest of the Analytics page (stat cards, categories, departments, top users) by date range. Would need `?since=YYYY-MM-DD` on six endpoints + service-layer SQL changes. Sized for its own PR.
- Localization of either page — these are still English-only.

## Test plan

- [ ] Visit `/kudos` (My Kudos): Sent and Received tabs both show full names like "You recognized Rahul Sharma" instead of "You recognized User #3". Avatar initials show `RS` instead of `U3`.
- [ ] Visit `/feed`: every public kudos card shows the sender's full name (or "Anonymous" when `is_anonymous`).
- [ ] Visit `/analytics`:
  - Six stat cards each have a different tone, value is the dominant element
  - Kudos Trends renders as a gradient area chart with the period total in the header
  - Click 7d → 30d → 90d → All; the chart re-fetches, a spinner overlays during the swap, and the subtitle updates ("Daily ... last 7 days" / "Weekly ... last 90 days" etc.)
  - Donut chart shows category total in the center and a colored legend on the right
  - Department bar chart has gradient bars with grey background tracks
  - Top Recognizers / Recognized: 1st has a crown icon, 2nd / 3rd have medals
- [ ] Empty states: load with an org that has no kudos / categories — each chart shows the icon + helper hint instead of plain text
- [ ] `pnpm --filter @emp-rewards/client exec tsc --noEmit` clean
- [ ] `pnpm --filter @emp-rewards/server exec tsc --noEmit` clean