### PR TITLE
fix(rewards): employees could view all nominations (scope to own)

### DIFF
--- a/packages/server/src/api/routes/nomination.routes.ts
+++ b/packages/server/src/api/routes/nomination.routes.ts
@@ -121,16 +121,28 @@ router.post("/", async (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
-// GET / — List nominations (admin view with filters)
+// GET / — List nominations. Admins (org_admin / hr_admin / super_admin) see
+// the whole org so they can review; everyone else is scoped to the
+// nominations they themselves submitted (the page is "nominations you have
+// submitted"). Scoping is enforced server-side so a non-admin can't widen it
+// by omitting/forging the nominatorId query param.
 router.get("/", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const orgId = req.user!.empcloudOrgId;
     const pagination = paginationSchema.parse(req.query);
     const programId = req.query.programId as string | undefined;
     const status = req.query.status as string | undefined;
-    const nominatorIdRaw = Number(req.query.nominatorId);
-    const nominatorId =
-      Number.isInteger(nominatorIdRaw) && nominatorIdRaw > 0 ? nominatorIdRaw : undefined;
+
+    const isAdmin = ["org_admin", "hr_admin", "super_admin"].includes(req.user!.role);
+    let nominatorId: number | undefined;
+    if (isAdmin) {
+      // Admins may optionally filter by a specific nominator.
+      const raw = Number(req.query.nominatorId);
+      nominatorId = Number.isInteger(raw) && raw > 0 ? raw : undefined;
+    } else {
+      // Non-admins only ever see their own nominations.
+      nominatorId = req.user!.empcloudUserId;
+    }
 
     const result = await nominationService.listNominations(orgId, {
       page: pagination.page,


### PR DESCRIPTION
Fixes a privacy/authorization leak: an employee viewing the Nominations page could see EVERY nomination in the org (nominator, nominee, and reason) â€” not just their own.

Root cause: GET /nominations was protected only by authenticate (no role gate), and the nominatorId filter was an optional query param that the client never sets for any role. So the endpoint returned the whole org's nominations to anyone authenticated.

Fix (server-side, can't be bypassed by the client):
- Admins (org_admin / hr_admin / super_admin) keep the full org view so they can review nominations, and may still filter by a specific nominatorId.
- Everyone else is forced to nominatorId = their own empcloudUserId, regardless of what the query param says.

The page subtitle was already role-aware ("Review and manage... across all programs" for admins vs. "Track nominations you have submitted" for employees) â€” only the data fetch was wrong.

Verified live:
- Employee â†’ sees only their own nomination (1 of 6).
- Employee forging ?nominatorId=<someone else> â†’ ignored, still only their own.
- Admin â†’ sees all 6.
Server typecheck clean.
