### PR TITLE
fix(rewards): auto-dismiss lingering redeem success/error banner

### DIFF
--- a/packages/client/src/pages/rewards/RewardCatalogPage.tsx
+++ b/packages/client/src/pages/rewards/RewardCatalogPage.tsx
@@ -102,10 +102,15 @@ export function RewardCatalogPage() {
     try {
       await apiPost(`/rewards/${rewardId}/redeem`);
       setSuccess(`Successfully redeemed "${rewardName}"!`);
+      // Auto-dismiss so a stale banner doesn't linger and look like it
+      // applies to the current (now-reduced) balance.
+      window.setTimeout(() => setSuccess(null), 4000);
       fetchBalance();
       fetchRewards();
     } catch (err: any) {
-      setError(err.response?.data?.error?.message || "Failed to redeem reward");
+      const msg = err.response?.data?.error?.message || "Failed to redeem reward";
+      setError(msg);
+      window.setTimeout(() => setError(null), 5000);
     } finally {
       setRedeemingId(null);
     }


### PR DESCRIPTION
Fixes a misleading UX on the Rewards catalog (this is NOT a points-validation bug — the server correctly rejects insufficient-points redeems with a 400).

What looked wrong: the screenshot showed a 60-pt balance, a 'Successfully redeemed Company Hoodie!' (300 pts) banner, and every card greyed out as 'Insufficient Points'. That reads as if a 300-pt item was redeemed on a 60-pt balance.

What actually happened: the user genuinely had 360 pts earlier, redeemed the 300-pt hoodie (balance -> 60), and the success banner simply never auto-cleared. It was set on redeem but only reset when the NEXT redeem starts — so it lingered indefinitely and appeared to apply to the now-reduced balance.

Fix: auto-dismiss the success banner after 4s and the error banner after 5s.

Verified: server-side validation is solid — redeeming the 300-pt hoodie with a 60-pt balance returns 400 'Insufficient points. You have 60 but need 300'. Client typecheck clean.