### PR TITLE
feat(rewards): 2h session timeout + session-expired message on login

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -89,11 +89,12 @@ api.interceptors.response.use(
         return api(originalRequest);
       }
 
-      // Refresh failed — clear session and redirect to login
+      // Refresh failed — clear session and redirect to login with a flag so
+      // the login page can explain why the user was signed out.
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
       localStorage.removeItem("user");
-      window.location.href = "/login";
+      window.location.href = "/login?session=expired";
     }
     return Promise.reject(error);
   }

--- a/packages/client/src/pages/auth/LoginPage.tsx
+++ b/packages/client/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Trophy, Eye, EyeOff, Loader2 } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Trophy, Eye, EyeOff, Loader2, Clock } from "lucide-react";
 import { useLogin } from "@/api/hooks";
 import { useAuthStore } from "@/lib/auth-store";
 import toast from "react-hot-toast";
@@ -18,6 +18,8 @@ const FEATURES = [
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sessionExpired = searchParams.get("session") === "expired";
   const loginMutation = useLogin();
   const login = useAuthStore((s) => s.login);
   const [email, setEmail] = useState("");
@@ -84,6 +86,16 @@ export function LoginPage() {
           <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
             <h2 className="text-2xl font-bold text-gray-900">Welcome back</h2>
             <p className="mt-1 text-sm text-gray-500">Sign in to recognize your team</p>
+
+            {sessionExpired && (
+              <div className="mt-4 flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 p-3.5 text-sm text-amber-800">
+                <Clock className="mt-0.5 h-4 w-4 shrink-0" />
+                <div>
+                  <p className="font-medium">Your session has expired</p>
+                  <p className="mt-0.5 text-amber-700">Please sign in again to continue.</p>
+                </div>
+              </div>
+            )}
 
             <form onSubmit={handleSubmit} className="mt-6 space-y-4">
               <div>

--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -37,7 +37,9 @@ export const config = {
   // JWT
   jwt: {
     secret: process.env.JWT_SECRET || "change-this-in-production",
-    accessExpiry: process.env.JWT_ACCESS_EXPIRY || "15m",
+    // Access token lasts 2h; refresh token (7d) keeps the session alive
+    // across access-token expiries via the client's silent refresh.
+    accessExpiry: process.env.JWT_ACCESS_EXPIRY || "2h",
     refreshExpiry: process.env.JWT_REFRESH_EXPIRY || "7d",
   },
 


### PR DESCRIPTION
Two changes:

1. Session length: access token now expires in 2h (was 15m). The 7-day refresh token keeps the user logged in across access-token expiries via the client's existing silent-refresh interceptor, so the effective session is still up to 7 days of activity. Changed the config default; JWT_ACCESS_EXPIRY env var still overrides it.

2. Session-expired message: when token refresh ultimately fails (refresh token gone or expired), the 401 interceptor now redirects to /login?session=expired instead of a bare /login, and the login page shows a clear amber notice — "Your session has expired — Please sign in again to continue." (with a clock icon, above the form).

Verified:
- A fresh login access token decodes to a 2.00h lifetime (was 15m).
- The login page renders the session-expired notice on ?session=expired (screenshot-confirmed).
- Server + client typecheck clean.

Note: .env is gitignored, so the committed change is the config default. Set JWT_ACCESS_EXPIRY=2h in each environment's .env to make it explicit there too (already done locally).