### PR TITLE
feat(client): light / dark theme system

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EMP Rewards — Employee Recognition & Rewards</title>
+    <script>
+      // Prevent FOUC: apply the persisted theme before first paint.
+      (function () {
+        try {
+          var t = localStorage.getItem("theme") || "system";
+          var dark =
+            t === "dark" ||
+            (t === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (dark) document.documentElement.classList.add("dark");
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/client/src/components/ThemeToggle.tsx
+++ b/packages/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { useTheme } from "@/lib/theme";
+import { Sun, Moon, Monitor } from "lucide-react";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const options = [
+    { value: "light" as const, icon: Sun, label: "Light" },
+    { value: "dark" as const, icon: Moon, label: "Dark" },
+    { value: "system" as const, icon: Monitor, label: "System" },
+  ];
+
+  return (
+    <div className="flex items-center rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+      {options.map((opt) => {
+        const Icon = opt.icon;
+        const active = theme === opt.value;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => setTheme(opt.value)}
+            title={opt.label}
+            aria-label={`${opt.label} theme`}
+            className={`rounded-md p-1.5 transition-colors ${
+              active
+                ? "bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white"
+                : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -23,6 +23,7 @@ import {
 import { isLoggedIn, getUser, useAuthStore } from "@/lib/auth-store";
 import { cn, getInitials } from "@/lib/utils";
 import { BackToDashboard } from "@/components/BackToDashboard";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface NavItem {
   to: string;
@@ -163,6 +164,7 @@ export function DashboardLayout() {
             </button>
           </div>
           <div className="flex items-center gap-3">
+            <ThemeToggle />
             <div className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-100 text-brand-700 text-xs font-semibold">
               {getInitials(displayName)}
             </div>

--- a/packages/client/src/lib/theme.tsx
+++ b/packages/client/src/lib/theme.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolved: "light" | "dark";
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  resolved: "light",
+  setTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    return (localStorage.getItem("theme") as Theme) || "system";
+  });
+
+  const [resolved, setResolved] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    function apply() {
+      let mode: "light" | "dark";
+      if (theme === "system") {
+        mode = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      } else {
+        mode = theme;
+      }
+      setResolved(mode);
+      document.documentElement.classList.toggle("dark", mode === "dark");
+    }
+
+    apply();
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, [theme]);
+
+  function setTheme(t: Theme) {
+    localStorage.setItem("theme", t);
+    setThemeState(t);
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolved, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "react-hot-toast";
 import App from "./App";
 import "./styles/globals.css";
 import { useAuthStore } from "./lib/auth-store";
+import { ThemeProvider } from "@/lib/theme";
 
 // Load existing session from localStorage
 useAuthStore.getState().loadFromStorage();
@@ -25,11 +26,19 @@ if ("serviceWorker" in navigator) {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-        <Toaster position="top-right" />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+          <Toaster
+            position="top-right"
+            toastOptions={{
+              className:
+                "!bg-white !text-gray-900 dark:!bg-gray-800 dark:!text-gray-100",
+            }}
+          />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/packages/client/src/pages/leaderboard/LeaderboardPage.tsx
+++ b/packages/client/src/pages/leaderboard/LeaderboardPage.tsx
@@ -40,9 +40,9 @@ function PodiumCard({
   place: 1 | 2 | 3;
 }) {
   const colors = {
-    1: { bg: "bg-amber-50", border: "border-amber-400", icon: "text-amber-500", ring: "ring-amber-400" },
-    2: { bg: "bg-gray-50", border: "border-gray-400", icon: "text-gray-400", ring: "ring-gray-300" },
-    3: { bg: "bg-orange-50", border: "border-orange-400", icon: "text-orange-400", ring: "ring-orange-300" },
+    1: { bg: "bg-amber-50 dark:bg-amber-500/15", border: "border-amber-400", icon: "text-amber-500", ring: "ring-amber-400" },
+    2: { bg: "bg-gray-100 dark:bg-gray-700", border: "border-gray-400 dark:border-gray-500", icon: "text-gray-400", ring: "ring-gray-300 dark:ring-gray-500" },
+    3: { bg: "bg-orange-50 dark:bg-orange-500/15", border: "border-orange-400", icon: "text-orange-400", ring: "ring-orange-300" },
   };
   const c = colors[place];
   const heights = { 1: "h-36", 2: "h-28", 3: "h-24" };
@@ -54,7 +54,7 @@ function PodiumCard({
     <div className={`flex flex-col items-center ${place === 1 ? "order-2" : place === 2 ? "order-1" : "order-3"}`}>
       <div className="relative mb-2">
         <div className={`flex h-16 w-16 items-center justify-center rounded-full ${c.bg} border-2 ${c.border} ring-2 ${c.ring}`}>
-          <User className="h-8 w-8 text-gray-400" />
+          <User className="h-8 w-8 text-gray-400 dark:text-gray-300" />
         </div>
         {place === 1 && (
           <Crown className="absolute -top-3 left-1/2 h-6 w-6 -translate-x-1/2 text-amber-500" />

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -11,7 +11,24 @@
   .dark {
     @apply bg-gray-950 text-gray-100;
   }
+  /* Tell the browser to paint native UI (scrollbars, form widgets) to
+     match the active theme — otherwise dark mode gets light scrollbars. */
+  :root { color-scheme: light; }
+  :root.dark { color-scheme: dark; }
 }
+
+/* Themed scrollbars in dark mode (WebKit/Chromium). color-scheme above
+   already fixes the native light-scrollbar-on-dark issue; this refines
+   the look so the track blends with the dark surfaces. */
+.dark ::-webkit-scrollbar { width: 12px; height: 12px; }
+.dark ::-webkit-scrollbar-track { background: #0b1120; }
+.dark ::-webkit-scrollbar-thumb {
+  background: #374151;
+  border: 3px solid #0b1120;
+  border-radius: 8px;
+}
+.dark ::-webkit-scrollbar-thumb:hover { background: #4b5563; }
+.dark ::-webkit-scrollbar-corner { background: #0b1120; }
 
 /* ------------------------------------------------------------------ *
  * Dark mode

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -6,4 +6,145 @@
   body {
     @apply bg-gray-50 text-gray-900 font-sans;
   }
+  .dark body,
+  body.dark,
+  .dark {
+    @apply bg-gray-950 text-gray-100;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Dark mode
+ * The app is authored in a light-only raw palette (bg-white / gray-*).
+ * Rather than migrate every utility across the codebase, dark mode is a
+ * self-contained set of overrides that recolor the stock gray/white
+ * utilities when `.dark` is present on <html>. Toggle lives in
+ * src/lib/theme.tsx.  (Same strategy as emp-payroll / emp-performance,
+ * with the amber brand kept intact.)
+ * ------------------------------------------------------------------ */
+
+/* Surfaces --------------------------------------------------------- */
+.dark .bg-white { background-color: #111827 !important; }
+.dark .bg-gray-50 { background-color: #030712 !important; }
+.dark .bg-gray-100 { background-color: #1f2937 !important; }
+.dark .bg-gray-200 { background-color: #374151 !important; }
+.dark .bg-gray-300 { background-color: #4b5563 !important; }
+.dark .bg-gray-400 { background-color: #4b5563 !important; }
+
+/* Borders ---------------------------------------------------------- */
+.dark .border-gray-50 { border-color: #1f2937 !important; }
+.dark .border-gray-100 { border-color: #1f2937 !important; }
+.dark .border-gray-200 { border-color: #1f2937 !important; }
+.dark .border-gray-300 { border-color: #374151 !important; }
+.dark .border-gray-400 { border-color: #4b5563 !important; }
+.dark .border-gray-900 { border-color: #6b7280 !important; }
+
+/* Dividers --------------------------------------------------------- */
+.dark .divide-gray-50 > :not([hidden]) ~ :not([hidden]) { border-color: #1f2937 !important; }
+.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) { border-color: #1f2937 !important; }
+.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]) { border-color: #374151 !important; }
+
+/* Text ------------------------------------------------------------- */
+.dark .text-gray-900 { color: #f3f4f6 !important; }
+.dark .text-gray-800 { color: #e5e7eb !important; }
+.dark .text-gray-700 { color: #d1d5db !important; }
+.dark .text-gray-600 { color: #9ca3af !important; }
+.dark .text-gray-500 { color: #9ca3af !important; }
+.dark .text-gray-400 { color: #6b7280 !important; }
+.dark .text-gray-300 { color: #4b5563 !important; }
+
+/* Hover states ----------------------------------------------------- */
+.dark .hover\:bg-gray-50:hover { background-color: #1f2937 !important; }
+.dark .hover\:bg-gray-100:hover { background-color: #374151 !important; }
+.dark .hover\:bg-gray-200:hover { background-color: #4b5563 !important; }
+.dark .hover\:text-gray-600:hover { color: #d1d5db !important; }
+.dark .hover\:text-gray-700:hover { color: #e5e7eb !important; }
+.dark .hover\:text-gray-800:hover { color: #f3f4f6 !important; }
+.dark .hover\:text-gray-900:hover { color: #f9fafb !important; }
+
+/* Semi-transparent surfaces --------------------------------------- */
+.dark .bg-gray-50\/30 { background-color: rgba(17, 24, 39, 0.3) !important; }
+.dark .bg-gray-50\/40 { background-color: rgba(17, 24, 39, 0.4) !important; }
+
+/* Form controls ---------------------------------------------------- */
+.dark input,
+.dark select,
+.dark textarea {
+  background-color: #1f2937 !important;
+  border-color: #374151 !important;
+  color: #f3f4f6 !important;
+}
+.dark input::placeholder,
+.dark textarea::placeholder { color: #6b7280 !important; }
+.dark input[type="checkbox"],
+.dark input[type="radio"] { background-color: transparent !important; }
+
+/* Cards / shadows -------------------------------------------------- */
+.dark .shadow-sm { box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3) !important; }
+.dark .shadow,
+.dark .shadow-md { box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4) !important; }
+.dark .shadow-lg { box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4) !important; }
+.dark .shadow-xl { box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5) !important; }
+
+/* Brand accents (amber/gold) — nudge for contrast on dark surfaces - */
+.dark .bg-brand-50 { background-color: rgba(245, 158, 11, 0.12) !important; }
+.dark .bg-brand-100 { background-color: rgba(245, 158, 11, 0.18) !important; }
+.dark .text-brand-600 { color: #fbbf24 !important; }
+.dark .text-brand-700 { color: #fbbf24 !important; }
+/* Solid brand buttons/gradients (bg-brand-600, from-brand-500 to-brand-700,
+   from-amber-500 to-amber-600) intentionally left unchanged. */
+
+/* Pale pastel gradient cards fade toward white / a light tint in light
+   mode; on dark those stops blow out — repaint the card as a dark panel.
+   Solid brand gradients are excluded above and keep their colour. */
+.dark .bg-gradient-to-br.from-amber-50,
+.dark .bg-gradient-to-br.from-orange-50,
+.dark .bg-gradient-to-br.from-purple-50,
+.dark .bg-gradient-to-br.from-blue-50,
+.dark .bg-gradient-to-br.from-pink-50 {
+  background-image: none !important;
+  background-color: #111827 !important;
+}
+
+/* Pale colored surfaces (stat pills, badges, status chips use bg-*-50 /
+   bg-*-100). On dark those wash out to near-white — swap them for a
+   translucent tint of the SAME hue so the colour language (green=earned,
+   red=spent, etc.) survives while the surface reads dark. */
+.dark .bg-green-50   { background-color: rgba(34, 197, 94, 0.12) !important; }
+.dark .bg-emerald-50 { background-color: rgba(16, 185, 129, 0.12) !important; }
+.dark .bg-red-50     { background-color: rgba(239, 68, 68, 0.12) !important; }
+.dark .bg-rose-50    { background-color: rgba(244, 63, 94, 0.12) !important; }
+.dark .bg-amber-50   { background-color: rgba(245, 158, 11, 0.12) !important; }
+.dark .bg-yellow-50  { background-color: rgba(234, 179, 8, 0.12) !important; }
+.dark .bg-orange-50  { background-color: rgba(249, 115, 22, 0.12) !important; }
+.dark .bg-blue-50    { background-color: rgba(59, 130, 246, 0.12) !important; }
+.dark .bg-sky-50     { background-color: rgba(14, 165, 233, 0.12) !important; }
+.dark .bg-indigo-50  { background-color: rgba(99, 102, 241, 0.12) !important; }
+.dark .bg-violet-50  { background-color: rgba(139, 92, 246, 0.12) !important; }
+.dark .bg-purple-50  { background-color: rgba(168, 85, 247, 0.12) !important; }
+.dark .bg-pink-50    { background-color: rgba(236, 72, 153, 0.12) !important; }
+.dark .bg-green-100   { background-color: rgba(34, 197, 94, 0.18) !important; }
+.dark .bg-emerald-100 { background-color: rgba(16, 185, 129, 0.18) !important; }
+.dark .bg-red-100     { background-color: rgba(239, 68, 68, 0.18) !important; }
+.dark .bg-rose-100    { background-color: rgba(244, 63, 94, 0.18) !important; }
+.dark .bg-amber-100   { background-color: rgba(245, 158, 11, 0.18) !important; }
+.dark .bg-yellow-100  { background-color: rgba(234, 179, 8, 0.18) !important; }
+.dark .bg-orange-100  { background-color: rgba(249, 115, 22, 0.18) !important; }
+.dark .bg-blue-100    { background-color: rgba(59, 130, 246, 0.18) !important; }
+.dark .bg-sky-100     { background-color: rgba(14, 165, 233, 0.18) !important; }
+.dark .bg-indigo-100  { background-color: rgba(99, 102, 241, 0.18) !important; }
+.dark .bg-violet-100  { background-color: rgba(139, 92, 246, 0.18) !important; }
+.dark .bg-purple-100  { background-color: rgba(168, 85, 247, 0.18) !important; }
+.dark .bg-pink-100    { background-color: rgba(236, 72, 153, 0.18) !important; }
+
+/* Recharts tooltips ------------------------------------------------ */
+.dark .recharts-default-tooltip {
+  background-color: #1f2937 !important;
+  border-color: #374151 !important;
+}
+.dark .recharts-tooltip-item { color: #f3f4f6 !important; }
+
+/* Print ------------------------------------------------------------ */
+@media print {
+  .dark { background: white !important; color: black !important; }
 }


### PR DESCRIPTION
## Light / Dark theme system

Adds a **light / dark / system** theme toggle to emp-rewards, matching the approach used across the EmpCloud ecosystem (emp-payroll / emp-performance).

### Approach
Class-based Tailwind dark mode (`darkMode: "class"`, already enabled) + a **self-contained block of override CSS** that recolors the app's raw gray/white/colored utilities when `.dark` is present on `<html>` — rather than migrating every utility to semantic tokens. The app is authored in a light-only raw palette, so this themes the whole app with **no page files touched**.

### What's included
- **`src/lib/theme.tsx`** — `ThemeProvider` / `useTheme` context. localStorage key `"theme"` (`light` | `dark` | `system`), live `prefers-color-scheme` listener, toggles `.dark` on `<html>`.
- **`src/components/ThemeToggle.tsx`** — 3-segment Sun / Moon / Monitor control, mounted in the `DashboardLayout` header.
- **`src/styles/globals.css`** — `.dark` overrides for surfaces, borders, dividers, text, hovers, form controls, shadows, the **amber brand** accents, pale pastel gradient cards, and pale colored stat/badge surfaces. The `bg-*-50` / `bg-*-100` colored tints (stat pills, podium tiers, badges) are swapped for translucent versions of the **same hue**, so the colour language (green = earned, red = spent, gold/silver/bronze podium, etc.) survives on dark instead of washing out.
- **`main.tsx`** — `ThemeProvider` wraps the app (outermost); `Toaster` gets a dark-aware className.
- **`index.html`** — inline FOUC guard applies the persisted theme before first paint.

The **amber/gold brand identity is preserved**.

### Verification
- Client-local `tsc --noEmit`: **0 errors**
- `vite build`: **passes**
- Playwright (login → dashboard + leaderboard, light & dark): **0 page errors**; `html.dark` toggles correctly; body bg `gray-50` (light) / `gray-950` (dark); 3-segment toggle present; stat pills and all three podium tiers render as dark tinted panels.