### PR TITLE
feat(ui): sidebar grouping + collapsible icon-only rail

### DIFF
--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -31,22 +31,51 @@ interface NavItem {
   adminOnly?: boolean;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/feed", label: "Feed", icon: MessageSquare },
-  { to: "/celebrations", label: "Celebrations", icon: PartyPopper },
-  { to: "/kudos", label: "Kudos", icon: Heart },
-  { to: "/leaderboard", label: "Leaderboard", icon: Trophy },
-  { to: "/badges", label: "Badges", icon: Award },
-  { to: "/rewards", label: "Rewards", icon: Gift },
-  { to: "/redemptions", label: "Redemptions", icon: ShoppingCart },
-  { to: "/challenges", label: "Challenges", icon: Swords },
-  { to: "/milestones", label: "Milestones", icon: Target },
-  { to: "/nominations", label: "Nominations", icon: Star },
-  { to: "/notifications", label: "Notifications", icon: Bell },
-  { to: "/budgets", label: "Budgets", icon: Wallet, adminOnly: true },
-  { to: "/analytics", label: "Analytics", icon: BarChart3, adminOnly: true },
-  { to: "/settings", label: "Settings", icon: Settings, adminOnly: true },
+interface NavSection {
+  title?: string;
+  items: NavItem[];
+}
+
+const NAV_SECTIONS: NavSection[] = [
+  {
+    items: [
+      { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { to: "/feed", label: "Feed", icon: MessageSquare },
+    ],
+  },
+  {
+    title: "Recognition",
+    items: [
+      { to: "/celebrations", label: "Celebrations", icon: PartyPopper },
+      { to: "/kudos", label: "Kudos", icon: Heart },
+      { to: "/nominations", label: "Nominations", icon: Star },
+      { to: "/badges", label: "Badges", icon: Award },
+    ],
+  },
+  {
+    title: "Rewards",
+    items: [
+      { to: "/rewards", label: "Rewards", icon: Gift },
+      { to: "/redemptions", label: "Redemptions", icon: ShoppingCart },
+      { to: "/challenges", label: "Challenges", icon: Swords },
+      { to: "/milestones", label: "Milestones", icon: Target },
+    ],
+  },
+  {
+    title: "Standings",
+    items: [
+      { to: "/leaderboard", label: "Leaderboard", icon: Trophy },
+      { to: "/notifications", label: "Notifications", icon: Bell },
+    ],
+  },
+  {
+    title: "Admin",
+    items: [
+      { to: "/budgets", label: "Budgets", icon: Wallet, adminOnly: true },
+      { to: "/analytics", label: "Analytics", icon: BarChart3, adminOnly: true },
+      { to: "/settings", label: "Settings", icon: Settings, adminOnly: true },
+    ],
+  },
 ];
 
 type Role = "super_admin" | "org_admin" | "hr_admin" | "hr_manager" | "employee";
@@ -87,27 +116,40 @@ export function DashboardLayout() {
         </div>
 
         {/* Nav */}
-        <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-1">
-          {NAV_ITEMS.filter((item) => {
-            if (item.adminOnly && !ADMIN_ROLES.includes((user?.role || "employee") as Role)) return false;
-            return true;
-          }).map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-brand-50 text-brand-700"
-                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                )
-              }
-            >
-              <item.icon className="h-5 w-5" />
-              {item.label}
-            </NavLink>
-          ))}
+        <nav className="flex-1 overflow-y-auto px-3 py-4">
+          {NAV_SECTIONS.map((section, si) => {
+            const isAdmin = ADMIN_ROLES.includes((user?.role || "employee") as Role);
+            const items = section.items.filter((item) => !item.adminOnly || isAdmin);
+            if (items.length === 0) return null;
+            return (
+              <div key={section.title || si} className={si > 0 ? "mt-6" : ""}>
+                {section.title && (
+                  <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                    {section.title}
+                  </p>
+                )}
+                <div className="space-y-1">
+                  {items.map((item) => (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      className={({ isActive }) =>
+                        cn(
+                          "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                          isActive
+                            ? "bg-brand-50 text-brand-700"
+                            : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                        )
+                      }
+                    >
+                      <item.icon className="h-5 w-5" />
+                      {item.label}
+                    </NavLink>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
         </nav>
 
         {/* User card */}

--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -19,6 +19,8 @@ import {
   Swords,
   Target,
   Bell,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { isLoggedIn, getUser, useAuthStore } from "@/lib/auth-store";
 import { cn, getInitials } from "@/lib/utils";
@@ -83,6 +85,9 @@ const ADMIN_ROLES: Role[] = ["super_admin", "org_admin", "hr_admin", "hr_manager
 
 export function DashboardLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem("sidebar-collapsed") === "true"
+  );
   const location = useLocation();
   const logout = useAuthStore((s) => s.logout);
 
@@ -92,6 +97,14 @@ export function DashboardLayout() {
   useEffect(() => {
     setMobileOpen(false);
   }, [location.pathname]);
+
+  function toggleCollapsed() {
+    setCollapsed((c) => {
+      const next = !c;
+      localStorage.setItem("sidebar-collapsed", String(next));
+      return next;
+    });
+  }
 
   const user = getUser();
   const displayName = user ? `${user.firstName} ${user.lastName}` : "User";
@@ -104,46 +117,63 @@ export function DashboardLayout() {
   };
   const roleLabel = ROLE_LABELS[user?.role || "employee"] || "Employee";
 
-  function SidebarContent() {
+  function SidebarContent({ collapsed = false }: { collapsed?: boolean }) {
     return (
-      <div className="flex h-full w-64 flex-col bg-white border-r border-gray-200">
+      <div
+        className={cn(
+          "flex h-full flex-col bg-white border-r border-gray-200 transition-[width] duration-200",
+          collapsed ? "w-16" : "w-64"
+        )}
+      >
         {/* Logo */}
-        <div className="flex h-16 items-center gap-3 px-6 border-b border-gray-100">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-500">
+        <div
+          className={cn(
+            "flex h-16 items-center gap-3 border-b border-gray-100",
+            collapsed ? "justify-center px-2" : "px-6"
+          )}
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-brand-500">
             <Trophy className="h-5 w-5 text-white" />
           </div>
-          <span className="text-lg font-bold text-gray-900">EMP Rewards</span>
+          {!collapsed && (
+            <span className="text-lg font-bold text-gray-900 truncate">EMP Rewards</span>
+          )}
         </div>
 
         {/* Nav */}
-        <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <nav className={cn("flex-1 overflow-y-auto py-4", collapsed ? "px-2" : "px-3")}>
           {NAV_SECTIONS.map((section, si) => {
             const isAdmin = ADMIN_ROLES.includes((user?.role || "employee") as Role);
             const items = section.items.filter((item) => !item.adminOnly || isAdmin);
             if (items.length === 0) return null;
             return (
-              <div key={section.title || si} className={si > 0 ? "mt-6" : ""}>
-                {section.title && (
-                  <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                    {section.title}
-                  </p>
-                )}
+              <div key={section.title || si} className={si > 0 ? (collapsed ? "mt-3" : "mt-6") : ""}>
+                {section.title &&
+                  (collapsed ? (
+                    si > 0 && <div className="mx-2 mb-2 border-t border-gray-100" />
+                  ) : (
+                    <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                      {section.title}
+                    </p>
+                  ))}
                 <div className="space-y-1">
                   {items.map((item) => (
                     <NavLink
                       key={item.to}
                       to={item.to}
+                      title={collapsed ? item.label : undefined}
                       className={({ isActive }) =>
                         cn(
-                          "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                          "flex items-center rounded-lg text-sm font-medium transition-colors",
+                          collapsed ? "justify-center px-2 py-2.5" : "gap-3 px-3 py-2",
                           isActive
                             ? "bg-brand-50 text-brand-700"
                             : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
                         )
                       }
                     >
-                      <item.icon className="h-5 w-5" />
-                      {item.label}
+                      <item.icon className="h-5 w-5 shrink-0" />
+                      {!collapsed && item.label}
                     </NavLink>
                   ))}
                 </div>
@@ -153,23 +183,33 @@ export function DashboardLayout() {
         </nav>
 
         {/* User card */}
-        <div className="border-t border-gray-200 p-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-100 text-brand-700 text-sm font-semibold">
-              {getInitials(displayName)}
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{displayName}</p>
-              <p className="text-xs text-gray-500">{roleLabel}</p>
-            </div>
+        <div className={cn("border-t border-gray-200", collapsed ? "p-2" : "p-4")}>
+          {collapsed ? (
             <button
               onClick={logout}
-              className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-              title="Logout"
+              title={`${displayName} — Sign out`}
+              className="mx-auto flex h-9 w-9 items-center justify-center rounded-full bg-brand-100 text-brand-700 text-sm font-semibold hover:bg-brand-200"
             >
-              <LogOut className="h-4 w-4" />
+              {getInitials(displayName)}
             </button>
-          </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-100 text-brand-700 text-sm font-semibold">
+                {getInitials(displayName)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">{displayName}</p>
+                <p className="text-xs text-gray-500">{roleLabel}</p>
+              </div>
+              <button
+                onClick={logout}
+                className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                title="Logout"
+              >
+                <LogOut className="h-4 w-4" />
+              </button>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -178,11 +218,24 @@ export function DashboardLayout() {
   return (
     <div className="flex h-screen bg-gray-50">
       {/* Desktop sidebar */}
-      <div className="hidden lg:block">
-        <SidebarContent />
+      <div className="relative hidden lg:block">
+        <SidebarContent collapsed={collapsed} />
+        {/* Collapse / expand toggle on the sidebar edge */}
+        <button
+          onClick={toggleCollapsed}
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          className="absolute top-20 -right-3 z-10 flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm hover:bg-gray-50 hover:text-gray-700"
+        >
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4" />
+          ) : (
+            <ChevronLeft className="h-4 w-4" />
+          )}
+        </button>
       </div>
 
-      {/* Mobile sidebar overlay */}
+      {/* Mobile sidebar overlay (always full width) */}
       {mobileOpen && (
         <div className="fixed inset-0 z-50 lg:hidden">
           <div className="fixed inset-0 bg-black/50" onClick={() => setMobileOpen(false)} />


### PR DESCRIPTION
## Sidebar improvements: grouping + collapsible rail

Two sequenced changes to the sidebar (`DashboardLayout.tsx`), building on each other:

**1. Group the nav into labelled sections** — the flat 15-item nav was hard to scan. Now grouped:
- *(top)* Dashboard, Feed
- **Recognition** — Celebrations, Kudos, Nominations, Badges
- **Rewards** — Rewards, Redemptions, Challenges, Milestones
- **Standings** — Leaderboard, Notifications
- **Admin** — Budgets, Analytics, Settings *(admin-only)*

Uppercase headers, spacing between groups, whole-section hiding for non-admins.

**2. Collapsible sidebar (icon-only rail)** — a `‹` / `›` toggle on the sidebar edge (like EmpCloud). Collapse shrinks it to a 64px icon-only rail: labels/wordmark hide, section headers become dividers, icons center with tooltips, user card becomes just the avatar. State persists in `localStorage` (`sidebar-collapsed`). Desktop only; mobile overlay stays full-width.

### Verification
- Client-local `tsc --noEmit`: **0 errors**
- Playwright: all sections + 15 nav links render; sidebar width toggles **256px ↔ 64px**; toggle persists; **0 page errors**; verified light + dark, expanded + collapsed.

Single file, two commits in sequence (grouping → collapse). Standalone on `main`.

Supersedes #38 (grouping alone), which is the first commit here.